### PR TITLE
Reduce target sdk version & code updates

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.SecUpwN.AIMSICD"
-          android:versionName="0.2.2"
+          android:versionName="0.1.1"
           android:versionCode="3"
           android:sharedUserId="android.uid.phone">
 
     <uses-sdk
-        android:minSdkVersion="14"
+        android:minSdkVersion="9"
         android:targetSdkVersion="19"/>
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>

--- a/res/layout/riloemhook_layout.xml
+++ b/res/layout/riloemhook_layout.xml
@@ -47,6 +47,13 @@
             />
 
         <RadioButton
+            android:id="@+id/radio_api6"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/radio_api6"
+            />
+
+        <RadioButton
             android:id="@+id/radio_api4"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -37,7 +37,8 @@
     <string name="radio_api2">API 2 (datalen=1)</string>
     <string name="radio_api3">API 3 (datalen=6)</string>
     <string name="radio_api4">API 4 Type command :</string>
-    <string name="radio_api5">API 5 Ciphering Indicator</string>
+    <string name="radio_api5">Ciphering Indicator - RilRAW</string>
+    <string name="radio_api6">Ciphering Indicator - ServiceMode</string>
     <string name="radio_run">RUN</string>
     <string name="ril_oem_response">Module response:</string>
 </resources>

--- a/src/com/SecUpwN/AIMSICD/AIMSICD.java
+++ b/src/com/SecUpwN/AIMSICD/AIMSICD.java
@@ -50,20 +50,20 @@ public class AIMSICD extends Activity {
             outputView.append("SIM serial:     " + Device.getSimSerial(false) + "\n\n");
         }
 
+        int netID = Device.getNetID(true);
         outputView.append("Device type:    " + Device.getPhoneType(false) + "\n");
         outputView.append("Device IMEI:    " + Device.getIMEI(false) + "\n");
         outputView.append("Device version: " + Device.getIMEIv(false) + "\n");
         outputView.append("Device num:     " + Device.getPhoneNumber(false) + "\n\n");
         outputView.append("Network name:   " + Device.getNetworkName(false) + "\n");
         outputView.append("Network code:   " + Device.getSmmcMcc(false) + "\n");
-        outputView.append("Network type:   " + Device.getsNetworkType(false) + "\n");
+        outputView.append("Network type:   " + Device.getNetworkTypeName() + "\n");
         outputView.append("Network LAC:    " + Device.getsLAC(false) + "\n");
         outputView.append("Network CellID: " + Device.getsCellId(false) + "\n\n");
 
-        outputView.append("Data activity:  " + Device.getsDataActivity(false) + "\n");
-        outputView.append("Data status:    " + Device.getsDataState(false) + "\n");
+        outputView.append("Data activity:  " + Device.getActivityDesc(netID) + "\n");
+        outputView.append("Data status:    " + Device.getStateDesc(netID) + "\n");
 
-        Device.kmlheader();
         outputView.append("--------------------------------\n");
         outputView.append("[LAC,CID]|DAct|DStat|Net|Sig|Lat|Lng\n");
         Log.i(TAG, "**** AIMSICD ****");
@@ -71,7 +71,7 @@ public class AIMSICD extends Activity {
         Log.i(TAG, "Device imei   : " + Device.getIMEI(false));
         Log.i(TAG, "Device version: " + Device.getIMEIv(false));
         Log.i(TAG, "Device num    : " + Device.getPhoneNumber(false));
-        Log.i(TAG, "Network type  : " + Device.getsNetworkType(false));
+        Log.i(TAG, "Network type  : " + Device.getNetworkTypeName());
         Log.i(TAG, "Network CellID: " + Device.getsCellId(false));
         Log.i(TAG, "Network LAC   : " + Device.getsLAC(false));
         Log.i(TAG, "Network code  : " + Device.getSmmcMcc(false));
@@ -93,16 +93,15 @@ public class AIMSICD extends Activity {
             menu.add(1, 1, 0, "Track Signal");
         }
         if (Device.isTrackingLocation()) {
-            menu.add(1, 2, 0, "Remove Loc.");
+            menu.add(1, 2, 0, "Untrack Location");
         } else {
-            menu.add(1, 2, 0, "Add Location");
+            menu.add(1, 2, 0, "Track Location");
         }
         menu.add(0, 4, 4, "Show Map");
 
         menu.add(0, 6, 6, "Quit");
-        menu.add(0, 7, 7, "Dump Session KML");
-        menu.add(0, 8, 8, "Export Database Tables");
-        menu.add(0, 9, 9, "AT OEM RIL Hook Test");
+        menu.add(0, 7, 7, "Export Database Tables");
+        menu.add(0, 8, 8, "AT OEM RIL Hook Test");
         menu.setGroupCheckable(1, true, false);
         return super.onCreateOptionsMenu(menu);
     }
@@ -130,12 +129,9 @@ public class AIMSICD extends Activity {
                 finish();
                 return true;
             case 7:
-                Device.dumpinfokml(mContext);
-                return true;
-            case 8:
                 Device.exportDB();
                 return true;
-            case 9:
+            case 8:
                 Intent intent = new Intent(this, ATRilHook.class);
                 startActivity(intent);
                 return true;
@@ -163,7 +159,7 @@ public class AIMSICD extends Activity {
                 webview.bringToFront();
             } else {
                 webview = new WebView(this);
-                webview.loadUrl("http://github.com/SecUpwN/Android-IMSI-Catcher-Detector");
+                webview.loadUrl("http://secupwn.github.io/Android-IMSI-Catcher-Detector/");
                 setContentView(webview);
             }
             isAbout = true;

--- a/src/com/SecUpwN/AIMSICD/Device.java
+++ b/src/com/SecUpwN/AIMSICD/Device.java
@@ -21,40 +21,38 @@ import android.util.Log;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 
 public class Device {
 
     private static String TAG = "AIMSICD_Device";
 
-    private static String LOCATION_TABLE = "locationinfo";
-    private static String CELL_TABLE = "cellinfo";
-    private static String SIGNAL_TABLE = "signalinfo";
-    private static String DB_NAME = "myCellInfo";
+    public static String LOCATION_TABLE = "locationinfo";
+    public static String CELL_TABLE = "cellinfo";
+    public static String SIGNAL_TABLE = "signalinfo";
+    public static String DB_NAME = "myCellInfo";
 
     private static PhoneStateListener sSignalListenerStrength;
     private static PhoneStateListener sSignalListenerLocation;
     private static LocationManager lm;
     private static LocationListener sLocationListener;
-    private static SQLiteDatabase sDB;
-    private static MySQLiteHelper dbHelper;
-
+    public static SQLiteDatabase sDB;
+    private static SQLiteHelper dbHelper;
 
     private static int sPhoneID;
     private static int sSignalInfo;
-    private static int sDataActivity;
     private static int sNetID;
     private static int sLacID;
     private static int sCellID;
     private static double sLongitude;
     private static double sLatitude;
-    private static String sCSV, sNetType, sCellInfo, sDataState;
-    private static String sKML, sPhoneNum, sCellType, sLac, sNetName, sMmcmcc, sSimCountry, sPhoneType;
-    private static String sIMEI, sIMEIV, sSimOperator, sSimOperatorName, sSimSerial, sSimSubs, sDataActivityType;
+    private static String sNetType = "", sCellInfo = "", sDataState = "";
+    private static String sKML = "", sPhoneNum = "", sCellType = "", sLac = "";
+    private static String sNetName = "", sMmcmcc = "", sSimCountry = "", sPhoneType = "";
+    private static String sIMEI = "", sIMEIV = "", sSimOperator = "", sSimOperatorName = "";
+    private static String sSimSerial = "", sSimSubs = "", sDataActivityType = "";
 
     private static boolean TrackingCell;
     private static boolean TrackingSignal;
@@ -97,128 +95,24 @@ public class Device {
         }
 
         //Network type
-        sNetID = tm.getNetworkType();
-        switch (sNetID) {
-            case TelephonyManager.NETWORK_TYPE_UNKNOWN:
-                sNetType = "Unknown";
-                break;
-            case TelephonyManager.NETWORK_TYPE_GPRS:
-                sNetType = "GPRS";
-                break;
-            case TelephonyManager.NETWORK_TYPE_EDGE:
-                sNetType = "EDGE";
-                break;
-            case TelephonyManager.NETWORK_TYPE_UMTS:
-                sNetType = "UMTS";
-                break;
-            case TelephonyManager.NETWORK_TYPE_HSDPA:
-                sNetType = "HSPA";
-                break;
-            case TelephonyManager.NETWORK_TYPE_HSUPA:
-                sNetType = "HDSPA";
-                break;
-            case TelephonyManager.NETWORK_TYPE_HSPA:
-                sNetType = "HUSPA";
-                break;
-            case TelephonyManager.NETWORK_TYPE_CDMA:
-                sNetType = "CDMA";
-                break;
-            case TelephonyManager.NETWORK_TYPE_EVDO_0:
-                sNetType = "EVDO_0";
-                break;
-            case TelephonyManager.NETWORK_TYPE_EVDO_A:
-                sNetType = "EVDO_A";
-                break;
-            case TelephonyManager.NETWORK_TYPE_1xRTT:
-                sNetType = "1xRTT";
-                break;
-            default:
-                sNetType = "Unknown";
-                break;
-        }
+        sNetID = getNetID(true);
+        sNetType = tm.getNetworkTypeName();
 
-        sDataActivity = tm.getDataActivity();
-        sDataActivityType = "undef";
-        switch (sDataActivity) {
-            case TelephonyManager.DATA_ACTIVITY_NONE:
-                sDataActivityType = "None";
-                break;
-            case TelephonyManager.DATA_ACTIVITY_IN:
-                sDataActivityType = "In";
-                break;
-            case TelephonyManager.DATA_ACTIVITY_OUT:
-                sDataActivityType = "Out";
-                break;
-            case TelephonyManager.DATA_ACTIVITY_INOUT:
-                sDataActivityType = "In-Out";
-                break;
-            case TelephonyManager.DATA_ACTIVITY_DORMANT:
-                sDataActivityType = "Dormant";
-                break;
-        }
+        int sDataActivity = tm.getDataActivity();
+        sDataActivityType = getActivityDesc(sDataActivity);
 
         sDataActivity = tm.getDataState();
-        sDataState = "undef";
-        switch (sDataActivity) {
-            case TelephonyManager.DATA_DISCONNECTED:
-                sDataActivityType = "Disconnected";
-                break;
-            case TelephonyManager.DATA_CONNECTING:
-                sDataActivityType = "Connecting";
-                break;
-            case TelephonyManager.DATA_CONNECTED:
-                sDataActivityType = "Connected";
-                break;
-            case TelephonyManager.DATA_SUSPENDED:
-                sDataActivityType = "Suspended";
-                break;
-        }
+        sDataState = getStateDesc(sDataActivity);
 
         //Create DB Instance
-        dbHelper = new MySQLiteHelper(mContext);
+        dbHelper = new SQLiteHelper(mContext);
         sDB = dbHelper.getWritableDatabase();
 
         sSignalListenerLocation = new PhoneStateListener() {
             public void onCellLocationChanged(CellLocation location) {
-                sNetID = tm.getNetworkType();
-                switch (sNetID) {
-                    case TelephonyManager.NETWORK_TYPE_UNKNOWN:
-                        sNetType = "Unknown";
-                        break;
-                    case TelephonyManager.NETWORK_TYPE_GPRS:
-                        sNetType = "GPRS";
-                        break;
-                    case TelephonyManager.NETWORK_TYPE_EDGE:
-                        sNetType = "EDGE";
-                        break;
-                    case TelephonyManager.NETWORK_TYPE_UMTS:
-                        sNetType = "UMTS";
-                        break;
-                    case TelephonyManager.NETWORK_TYPE_HSDPA:
-                        sNetType = "HDSPA";
-                        break;
-                    case TelephonyManager.NETWORK_TYPE_HSUPA:
-                        sNetType = "HSUPA";
-                        break;
-                    case TelephonyManager.NETWORK_TYPE_HSPA:
-                        sNetType = "HSPA";
-                        break;
-                    case TelephonyManager.NETWORK_TYPE_CDMA:
-                        sNetType = "CDMA";
-                        break;
-                    case TelephonyManager.NETWORK_TYPE_EVDO_0:
-                        sNetType = "EVDO_0";
-                        break;
-                    case TelephonyManager.NETWORK_TYPE_EVDO_A:
-                        sNetType = "EVDO_A";
-                        break;
-                    case TelephonyManager.NETWORK_TYPE_1xRTT:
-                        sNetType = "1xRTT";
-                        break;
-                    default:
-                        sNetType = "Unknown";
-                        break;
-                }
+                sNetID = getNetID(true);
+                sNetType = tm.getNetworkTypeName();
+
                 int dataActivityType = tm.getDataActivity();
                 String dataActivity = "un";
                 switch (dataActivityType) {
@@ -268,9 +162,9 @@ public class Device {
                                 sSimOperator = getSimOperator(true);
                                 sSimOperatorName = getSimOperatorName(true);
                                 dbHelper.insertCell(sDB, sLacID, sCellID, sNetID, sLatitude,
-                                        sLongitude, sSignalInfo, sCellInfo, sSimCountry,                                        sSimOperator, sSimOperatorName);
+                                        sLongitude, sSignalInfo, sCellInfo, sSimCountry,
+                                        sSimOperator, sSimOperatorName);
                             }
-                            kmlpoints(sLacID, sCellID, sCellInfo, sLongitude, sLatitude);
                         }
                         break;
                     case TelephonyManager.PHONE_TYPE_CDMA:
@@ -284,14 +178,9 @@ public class Device {
                                 sSimOperator = getSimOperator(true);
                                 sSimOperatorName = getNetworkName(true);
                             }
-                            kmlpoints(sLacID, sCellID, sCellInfo, sLongitude, sLatitude);
                         }
                 }
 
-                if (TrackingLocation) {
-                    dbHelper.insertLocation(sDB, sLacID, sCellID, sNetID, sLatitude, sLongitude,
-                            sSignalInfo, sCellInfo);
-                }
                 if (TrackingCell && !dbHelper.cellExists(sCellID)) {
                     dbHelper.insertCell(sDB, sLacID, sCellID, sNetID, sLatitude, sLongitude,
                             sSignalInfo, sCellInfo, sSimCountry, sSimOperator, sSimOperatorName);
@@ -313,7 +202,7 @@ public class Device {
                     default:
                         sSignalInfo = 0;
                 }
-                kmlpoints(sLacID, sCellID, sCellInfo, sLongitude, sLatitude);
+
                 if (TrackingSignal) {
                     dbHelper.insertSignal(sDB, sLacID, sCellID, sNetID, sLatitude, sLongitude,
                             sSignalInfo, sCellInfo);
@@ -413,49 +302,17 @@ public class Device {
         return sMmcmcc;
     }
 
-    public static String getsNetworkType(boolean force) {
-        if (sNetType.isEmpty() || force) {
-            switch (tm.getNetworkType()) {
-                case TelephonyManager.NETWORK_TYPE_UNKNOWN:
-                    sNetType = "Unknown";
-                    break;
-                case TelephonyManager.NETWORK_TYPE_GPRS:
-                    sNetType = "GPRS";
-                    break;
-                case TelephonyManager.NETWORK_TYPE_EDGE:
-                    sNetType = "EDGE";
-                    break;
-                case TelephonyManager.NETWORK_TYPE_UMTS:
-                    sNetType = "UMTS";
-                    break;
-                case TelephonyManager.NETWORK_TYPE_HSDPA:
-                    sNetType = "HDSPA";
-                    break;
-                case TelephonyManager.NETWORK_TYPE_HSUPA:
-                    sNetType = "HSUPA";
-                    break;
-                case TelephonyManager.NETWORK_TYPE_HSPA:
-                    sNetType = "HSPA";
-                    break;
-                case TelephonyManager.NETWORK_TYPE_CDMA:
-                    sNetType = "CDMA";
-                    break;
-                case TelephonyManager.NETWORK_TYPE_EVDO_0:
-                    sNetType = "EVDO_0";
-                    break;
-                case TelephonyManager.NETWORK_TYPE_EVDO_A:
-                    sNetType = "EVDO_A";
-                    break;
-                case TelephonyManager.NETWORK_TYPE_1xRTT:
-                    sNetType = "1xRTT";
-                    break;
-                default:
-                    sNetType = "Unknown";
-                    break;
-            }
+    public static String getNetworkTypeName() {
+        return tm.getNetworkTypeName();
+
+    }
+
+    public static int getNetID (boolean force) {
+        if (sNetID < 0 || force) {
+            sNetID = tm.getNetworkType();
         }
 
-        return sNetType;
+        return sNetID;
     }
 
     public static String getsLAC(boolean force) {
@@ -480,50 +337,43 @@ public class Device {
         return sCellType;
     }
 
-    public static String getsDataActivity(boolean force) {
-        if (sDataActivityType.isEmpty() || force) {
-            sDataActivity = tm.getDataActivity();
-            sDataActivityType = "undef";
-            switch (sDataActivity) {
-                case TelephonyManager.DATA_ACTIVITY_NONE:
-                    sDataActivityType = "None";
-                    break;
-                case TelephonyManager.DATA_ACTIVITY_IN:
-                    sDataActivityType = "In";
-                    break;
-                case TelephonyManager.DATA_ACTIVITY_OUT:
-                    sDataActivityType = "Out";
-                    break;
-                case TelephonyManager.DATA_ACTIVITY_INOUT:
-                    sDataActivityType = "In-Out";
-                    break;
-                case TelephonyManager.DATA_ACTIVITY_DORMANT:
-                    sDataActivityType = "Dormant";
-                    break;
-            }
+    public static String getActivityDesc(int dataID) {
+        sDataActivityType = "undef";
+        switch (dataID) {
+            case TelephonyManager.DATA_ACTIVITY_NONE:
+                sDataActivityType = "None";
+                break;
+            case TelephonyManager.DATA_ACTIVITY_IN:
+                sDataActivityType = "In";
+                break;
+            case TelephonyManager.DATA_ACTIVITY_OUT:
+                sDataActivityType = "Out";
+                break;
+            case TelephonyManager.DATA_ACTIVITY_INOUT:
+                sDataActivityType = "In-Out";
+                break;
+            case TelephonyManager.DATA_ACTIVITY_DORMANT:
+                sDataActivityType = "Dormant";
+                break;
         }
-
         return sDataActivityType;
     }
 
-    public static String getsDataState(boolean force) {
-        if (sDataState.isEmpty() || force) {
-            sDataActivity = tm.getDataState();
-            sDataState = "undef";
-            switch (sDataActivity) {
-                case TelephonyManager.DATA_DISCONNECTED:
-                    sDataActivityType = "Disconnected";
-                    break;
-                case TelephonyManager.DATA_CONNECTING:
-                    sDataActivityType = "Connecting";
-                    break;
-                case TelephonyManager.DATA_CONNECTED:
-                    sDataActivityType = "Connected";
-                    break;
-                case TelephonyManager.DATA_SUSPENDED:
-                    sDataActivityType = "Suspended";
-                    break;
-            }
+    public static String getStateDesc(int dataID) {
+        sDataState = "undef";
+        switch (dataID) {
+            case TelephonyManager.DATA_DISCONNECTED:
+                sDataActivityType = "Disconnected";
+                break;
+            case TelephonyManager.DATA_CONNECTING:
+                sDataActivityType = "Connecting";
+                break;
+            case TelephonyManager.DATA_CONNECTED:
+                sDataActivityType = "Connected";
+                break;
+            case TelephonyManager.DATA_SUSPENDED:
+                sDataActivityType = "Suspended";
+                break;
         }
 
         return sDataState;
@@ -605,6 +455,10 @@ public class Device {
                 sLongitude = loc.getLongitude();
                 sLatitude = loc.getLatitude();
             }
+            if (TrackingLocation) {
+                dbHelper.insertLocation(sDB, sLacID, sCellID, sNetID, sLatitude, sLongitude,
+                        sSignalInfo, sCellInfo);
+            }
         }
 
         @Override
@@ -624,118 +478,6 @@ public class Device {
         }
     }
 
-    public static void kmlheader() {
-        sKML = "<kml xmlns=\"http://earth.google.com/kml/2.0\">\n";
-        sKML += "<Folder>\n";
-        sKML += "<name>AIMSICD</name>\n";
-        sKML += "<description><![CDATA[AIMSICD LAC and CellID logs]]></description>\n";
-    }
-
-    private static void kmlpoints(int lac, int cellid, String info, double lng, double lat) {
-        if ((lng != 0.0) || (lat != 0.0)) {
-            //String timestamp = new java.text.SimpleDateFormat("yyyy-MM-ddTHH:mm:ss").format(new java.util.Date (epoch*1000));
-            alPosition.add(lng + "," + lat);
-            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            java.util.Date date = new java.util.Date();
-            String datetime = dateFormat.format(date);
-            sKML += "<Placemark>\n";
-            sKML += "<TimeStamp><when>" + datetime + "</when></TimeStamp>\n";
-            sKML += "<name>" + lac + " " + cellid + "</name>\n";
-            sKML += "<description><![CDATA[" + info + "]]></description>\n";
-            sKML += "<Style><IconStyle><color>ffffbebe</color><scale>0.5</scale></IconStyle></Style><Point><coordinates>" + lng + "," + lat + ",0</coordinates></Point>\n";
-            sKML += "</Placemark>\n";
-        }
-    }
-
-    private static String kmlLAC(String content) {
-        return poligon(sLacID, alPosition, content);
-    }
-
-    private static String poligon(int lac, ArrayList<String> alPosition, String content) {
-        //Collections.sort(alPosition);
-        if (alPosition.size() > 0) {
-            String[] aPosition = new String[alPosition.size()];
-            alPosition.toArray(aPosition);
-            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            java.util.Date date = new java.util.Date();
-            String datetime = dateFormat.format(date);
-
-            content += "<Placemark>\n";
-            content += "  <TimeStamp><when>" + datetime + "</when></TimeStamp>\n";
-            content += "  <name>LAC " + lac + "</name>\n";
-            content += "  <description><![CDATA[LAC " + lac + "]]></description>\n";
-            content += "  <Style><PolyStyle><color>7f9e9eff</color></PolyStyle></Style><MultiGeometry><Polygon><outerBoundaryIs><LinearRing><coordinates>";
-            String initpos = aPosition[0];
-            for (String pos : aPosition) {
-                content += " " + pos;
-            }
-            content += " " + initpos + "\n</coordinates></LinearRing></outerBoundaryIs></Polygon></MultiGeometry>\n";
-            content += "</Placemark>\n";
-        }
-        return content;
-    }
-
-    public static void dumpinfokml(Context context) {
-        try {
-            String state = Environment.getExternalStorageState();
-            if (Environment.MEDIA_MOUNTED.equals(state)) {
-                File rootcasirectory = new File(Environment.getExternalStorageDirectory() + "/AIMSICD/");
-                // have the object build the directory structure, if needed.
-                rootcasirectory.mkdirs();
-                // create a File object for the output file
-
-                // Make a copy of current content
-                String buff = sKML;
-                buff = kmlLAC(buff);
-                buff += "</Folder>\n</kml>\n";
-
-                SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd-HHmmss");
-                java.util.Date date = new java.util.Date();
-                String datetime = dateFormat.format(date);
-
-                File file = new File(rootcasirectory, "aimsicd-"+datetime+".kml");
-                try {
-                    OutputStream os = new FileOutputStream(file);
-
-                    os.write(buff.getBytes());
-                } catch (IOException e) {
-                    // Unable to create file, likely because external storage is
-                    // not currently mounted.
-                    Log.e(TAG, "ExternalStorage: Error writing " + file + e.getMessage());
-                }
-
-                AlertDialog.Builder msg = new AlertDialog.Builder(context);
-                msg.setMessage("KML log copied in " + file);
-                AlertDialog alert = msg.create();
-                alert.setTitle("Log:");
-                alert.show();
-            } else if (Environment.MEDIA_MOUNTED_READ_ONLY.equals(state)) {
-                // We can only read the media
-                AlertDialog.Builder msg = new AlertDialog.Builder(context);
-                msg.setMessage("Sorry, your SD card is mounted in read only mode. Write access is required to your SD card.");
-                AlertDialog alert = msg.create();
-                alert.setTitle("Error:");
-                alert.show();
-            } else {
-                // Something else is wrong. It may be one of many other states, but all we need
-                //  to know is we can neither read nor write
-                AlertDialog.Builder msg = new AlertDialog.Builder(context);
-                msg.setMessage("Sorry, I could not find an SD card to copy the log.");
-                AlertDialog alert = msg.create();
-                alert.setTitle("Error:");
-                alert.show();
-            }
-        } catch (Exception e) {
-            AlertDialog.Builder msg = new AlertDialog.Builder(context);
-            msg.setMessage("Something unexpected happened: " + e.getMessage());
-            AlertDialog alert = msg.create();
-            alert.setTitle("Error!");
-            alert.setIcon(R.drawable.icon);
-            alert.show();
-            e.printStackTrace();
-        }
-    }
-
     public static void exportDB () {
         try {
             dbHelper.export(LOCATION_TABLE);
@@ -749,7 +491,7 @@ public class Device {
     /**
      * SQLiteHelper class for the Location, Cell and Signal Strength Databases
      */
-    public static class MySQLiteHelper extends SQLiteOpenHelper {
+    public static class SQLiteHelper extends SQLiteOpenHelper {
 
         public static final String COLUMN_ID = "_id";
         private static final int DATABASE_VERSION = 1;
@@ -774,7 +516,7 @@ public class Device {
                 "Net VARCHAR, Lat VARCHAR, Lng VARCHAR, Signal INTEGER, Connection VARCHAR, " +
                 "Timestamp TIMESTAMP NOT NULL DEFAULT current_timestamp);";
 
-        public MySQLiteHelper(Context context) {
+        public SQLiteHelper(Context context) {
             super(context, DB_NAME, null, DATABASE_VERSION);
         }
 
@@ -830,7 +572,7 @@ public class Device {
 
         @Override
         public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-            Log.w(MySQLiteHelper.class.getName(),
+            Log.w(SQLiteHelper.class.getName(),
                     "Upgrading database from version " + oldVersion + " to "
                             + newVersion + ", which will destroy all old data");
             db.execSQL("DROP TABLE IF EXISTS " + LOCATION_TABLE);

--- a/src/com/SecUpwN/AIMSICD/MapViewer.java
+++ b/src/com/SecUpwN/AIMSICD/MapViewer.java
@@ -1,8 +1,6 @@
 package com.SecUpwN.AIMSICD;
 
 import android.database.Cursor;
-import android.database.sqlite.SQLiteDatabase;
-import android.database.sqlite.SQLiteException;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Point;
@@ -13,6 +11,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.webkit.WebView;
 import android.widget.ImageView;
+import com.SecUpwN.AIMSICD.cmdprocessor.Helpers;
 import com.google.android.maps.*;
 
 import java.util.List;
@@ -21,11 +20,9 @@ import java.util.List;
 public class MapViewer extends MapActivity {
     private final String TAG = "AIMSICD_MapViewer";
 
-    public MapView mapv;
+    public MapView mapView;
+
     private MapController mapc;
-    private SQLiteDatabase myDB;
-    private final String DB_NAME = "myCellInfo";
-    private final String TABLE_NAME = "locationinfo";
     private final int SIGNAL_SIZE_RATIO = 15;
 
     class MapOverlay extends com.google.android.maps.Overlay {
@@ -41,7 +38,7 @@ public class MapViewer extends MapActivity {
 
         @Override
         public void draw(Canvas canvas, MapView mapView, boolean shadow) {
-            int pradius = (int) mapv.getProjection().metersToEquatorPixels(radius);
+            int pradius = (int) mapView.getProjection().metersToEquatorPixels(radius);
 
             Log.i(TAG, " ==> Draw pos: " + gp1.toString() + " color: " + color + " radius: " + radius + " pradius: " + pradius);
             Projection projection = mapView.getProjection();
@@ -65,18 +62,10 @@ public class MapViewer extends MapActivity {
         setContentView(R.layout.map);
 
         ImageView imagev = new ImageView(this);
-        mapv = (MapView) findViewById(R.id.mapView);
-        mapv.setBuiltInZoomControls(true);
-        mapv.displayZoomControls(true);
-
-        myDB = null;
-        try {
-            myDB = this.openOrCreateDatabase(DB_NAME, MODE_PRIVATE, null);
-            loadentries();
-        } catch (SQLiteException se) {
-            Log.e(getClass().getSimpleName(), "Could not Open the database:" + se);
-            myDB = null;
-        }
+        mapView = (MapView) findViewById(R.id.mapView);
+        mapView.setBuiltInZoomControls(true);
+        mapView.displayZoomControls(true);
+        loadentries();
     }
 
     @Override
@@ -114,7 +103,7 @@ public class MapViewer extends MapActivity {
 
     private final void about() {
         WebView webview = new WebView(this);
-        webview.loadUrl("http://github.com/SecUpwN/Android-IMSI-Catcher-Detector");
+        webview.loadUrl("http://secupwn.github.io/Android-IMSI-Catcher-Detector/");
         webview.canGoBack();
         setContentView(webview);
     }
@@ -122,83 +111,81 @@ public class MapViewer extends MapActivity {
     private void loadentries() {
         double dlat = 0.0;
         double dlng = 0.0;
-        String datainfo = "undef";
         int net = 0;
         int signal = 0;
-        int lac = 0;
-        int cellid = 0;
         int radius = 0;
         GeoPoint p = null;
-        mapc = mapv.getController();
+        mapc = mapView.getController();
         int color = 0x000000;
-        // 	_id INTEGER primary key autoincrement, Lac INTEGER, CellID INTEGER, Net VARCHAR, Lat VARCHAR, Lng VARCHAR, Signal INTEGER, Connection VARCHAR, Timestamp TIMESTAMP NOT NULL DEFAULT current_timestamp);"
-        Cursor c = myDB.query(true, TABLE_NAME, new String[] { "Net", "Lat", "Lng", "Signal", "Connection" }, null, null, null, null, "Timestamp", null);
-
-        if (c.moveToFirst()) {
-            List<Overlay> listOfOverlays = mapv.getOverlays();
-            do {
-                net = c.getInt(0);
-                dlat = Double.parseDouble(c.getString(1));
-                dlng = Double.parseDouble(c.getString(2));
-                signal = c.getInt(3);
-                datainfo = c.getString(4);
-                if (signal == 0) {
-                    signal = 20;
-                }
-
-                if ((dlat != 0.0) || (dlng != 0.0)) {
-                    p = new GeoPoint((int) (dlat * 1E6), (int) (dlng * 1E6));
-                    radius = signal * SIGNAL_SIZE_RATIO;
-                    switch (net) {
-                        case TelephonyManager.NETWORK_TYPE_UNKNOWN:
-                            color = 0xF0F8FF;
-                            break;
-                        case TelephonyManager.NETWORK_TYPE_GPRS:
-                            color = 0xA9A9A9;
-                            break;
-                        case TelephonyManager.NETWORK_TYPE_EDGE:
-                            color = 0x87CEFA;
-                            break;
-                        case TelephonyManager.NETWORK_TYPE_UMTS:
-                            color = 0x7CFC00;
-                            break;
-                        case TelephonyManager.NETWORK_TYPE_HSDPA:
-                            color = 0xFF6347;
-                            break;
-                        case TelephonyManager.NETWORK_TYPE_HSUPA:
-                            color = 0xFF00FF;
-                            break;
-                        case TelephonyManager.NETWORK_TYPE_HSPA:
-                            color = 0x238E6B;
-                            break;
-                        case TelephonyManager.NETWORK_TYPE_CDMA:
-                            color = 0x8A2BE2;
-                            break;
-                        case TelephonyManager.NETWORK_TYPE_EVDO_0:
-                            color = 0xFF69B4;
-                            break;
-                        case TelephonyManager.NETWORK_TYPE_EVDO_A:
-                            color = 0xFFFF00;
-                            break;
-                        case TelephonyManager.NETWORK_TYPE_1xRTT:
-                            color = 0x7CFC00;
-                            break;
-                        default:
-                            color = 0xF0F8FF;
-                            break;
+        Cursor c = Device.sDB.rawQuery("SELECT Net, Lat, Lng, Signal FROM "
+                + Device.LOCATION_TABLE, null);
+        if (c.getCount()>0) {
+            if (c.moveToFirst()) {
+                List<Overlay> listOfOverlays = mapView.getOverlays();
+                do {
+                    net = c.getInt(0);
+                    dlat = Double.parseDouble(c.getString(1));
+                    dlng = Double.parseDouble(c.getString(2));
+                    signal = c.getInt(3);
+                    if (signal == 0) {
+                        signal = 20;
                     }
-                    Log.i(TAG, " ==> Poin:" + p.toString() + " radius: " + radius + " color: " + color + " signal:" + signal);
-                    listOfOverlays.add(new MapOverlay(p, radius, color));
-                }
-                // mapv.invalidate();
 
-            } while (c.moveToNext());
-            c.close();
-            mapc.setCenter(p);
+                    if ((dlat != 0.0) || (dlng != 0.0)) {
+                        p = new GeoPoint((int) (dlat * 1E6), (int) (dlng * 1E6));
+                        radius = signal * SIGNAL_SIZE_RATIO;
+                        switch (net) {
+                            case TelephonyManager.NETWORK_TYPE_UNKNOWN:
+                                color = 0xF0F8FF;
+                                break;
+                            case TelephonyManager.NETWORK_TYPE_GPRS:
+                                color = 0xA9A9A9;
+                                break;
+                            case TelephonyManager.NETWORK_TYPE_EDGE:
+                                color = 0x87CEFA;
+                                break;
+                            case TelephonyManager.NETWORK_TYPE_UMTS:
+                                color = 0x7CFC00;
+                                break;
+                            case TelephonyManager.NETWORK_TYPE_HSDPA:
+                                color = 0xFF6347;
+                                break;
+                            case TelephonyManager.NETWORK_TYPE_HSUPA:
+                                color = 0xFF00FF;
+                                break;
+                            case TelephonyManager.NETWORK_TYPE_HSPA:
+                                color = 0x238E6B;
+                                break;
+                            case TelephonyManager.NETWORK_TYPE_CDMA:
+                                color = 0x8A2BE2;
+                                break;
+                            case TelephonyManager.NETWORK_TYPE_EVDO_0:
+                                color = 0xFF69B4;
+                                break;
+                            case TelephonyManager.NETWORK_TYPE_EVDO_A:
+                                color = 0xFFFF00;
+                                break;
+                            case TelephonyManager.NETWORK_TYPE_1xRTT:
+                                color = 0x7CFC00;
+                                break;
+                            default:
+                                color = 0xF0F8FF;
+                                break;
+                        }
+                        Log.i(TAG, " ==> Poin:" + p.toString() + " radius: " + radius + " color: " + color + " signal:" + signal);
+                        listOfOverlays.add(new MapOverlay(p, radius, color));
+                    }
+
+                } while (c.moveToNext());
+                c.close();
+                mapc.setCenter(p);
+            }
+        } else {
+            Helpers.msgShort(this, "No tracked locations found to overlay on map.");
         }
         mapc.setZoom(14);
-        mapv.setSatellite(false);
-        mapv.invalidate();
+        mapView.setSatellite(false);
+        mapView.invalidate();
     }
 
     private final void quit() {
@@ -206,7 +193,7 @@ public class MapViewer extends MapActivity {
     }
 
     private final void erasedb() {
-        myDB.delete(TABLE_NAME, null, null);
+        Device.sDB.delete(Device.LOCATION_TABLE, null, null);
     }
 }
 

--- a/src/com/SecUpwN/AIMSICD/Utils.java
+++ b/src/com/SecUpwN/AIMSICD/Utils.java
@@ -1,11 +1,7 @@
 package com.SecUpwN.AIMSICD;
 
-
-import android.app.AlertDialog;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.util.Log;
-import android.widget.Toast;
 import com.SecUpwN.AIMSICD.cmdprocessor.CMDProcessor;
 import com.stericson.RootTools.RootTools;
 
@@ -154,4 +150,5 @@ public class Utils {
         mListString.toArray(mResult);
         return mResult;
     }
+
 }

--- a/src/com/SecUpwN/AIMSICD/cmdprocessor/Helpers.java
+++ b/src/com/SecUpwN/AIMSICD/cmdprocessor/Helpers.java
@@ -44,6 +44,7 @@ public class Helpers {
             "DynamicRegexReplaceableByCompiledPattern",
             "BreakStatement"
     })
+
     // avoids hardcoding the tag
     private static final String TAG = "AIMSICD_Helpers";
 


### PR DESCRIPTION
Minimum Android SDK version reduced to SDK 9 - Gingerbread to target a wider range of devices,
a number of code changes were required to comply with the SDK 9 level requirements.

Further changes made to the ATRilHook class in an attempt to access the invokeOemRilRequestStrings method correctly, also some updates made to the handling of OemRilRaw requests and their response. Method currently displays the Ciphering Indicator provided through the SamsungServiceMode methods which unfortunately would probably be specific to Samsung devices (testing required). Currently investigating the layout of the byte[] layout to enable further access to these functions and a greater understanding of what the Raw request expects.

Mapviewer updated although an issue still exists when the location table is empty causing a NPE when trying to overlay stored locations onto the Map, this is currently being worked on to correct this issue.
