### PR TITLE
Add Android.mk for CyanogenMod build

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,37 @@
+LOCAL_PATH:= $(call my-dir)
+
+ifneq ($(TARGET_SIMULATOR),true)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE_TAGS := optional
+
+LOCAL_SRC_FILES := $(call all-java-files-under, src)
+LOCAL_PACKAGE_NAME := Android-IMSI-Catcher-Detector
+LOCAL_JAVA_LIBRARIES := telephony-common effects maps usb
+LOCAL_STATIC_JAVA_LIBRARIES := android-support-v13 RootTools
+LOCAL_PROGUARD_ENABLED := disabled
+LOCAL_CERTIFICATE := platform
+
+include $(BUILD_PACKAGE)
+
+###########################################################
+include $(CLEAR_VARS)
+
+# XXX: manually create symlink to addon-google_apis-google-17
+# ln -s ${ANDROID_HOME}/add-ons/addon-google_apis-google-17 addon-google_apis-google-17
+GOOGLE_APIS_ADDON = addon-google_apis-google-17/libs
+
+LOCAL_PREBUILT_STATIC_JAVA_LIBRARIES := RootTools:libs/RootTools.jar
+LOCAL_PREBUILT_JAVA_LIBRARIES := \
+    effects:${GOOGLE_APIS_ADDON}/effects.jar \
+    maps:${GOOGLE_APIS_ADDON}/maps.jar \
+    usb:${GOOGLE_APIS_ADDON}/usb.jar
+
+include $(BUILD_MULTI_PREBUILT)
+############################################################
+
+# Build the test package
+include $(call all-makefiles-under,$(LOCAL_PATH))
+
+endif # TARGET_SIMULATOR


### PR DESCRIPTION
I have build this application for CyanogenMod 10-1.

[Release file](https://github.com/illarionov/Android-IMSI-Catcher-Detector/releases/tag/0.1.2.cm-alpha)

There were some problems building this with prebuild framework/telephony libraries, so I used CyanogenMod sources and Android.mk (something like as [SamsungServiceMode app](https://github.com/CyanogenMod/android_packages_apps_SamsungServiceMode)). Maybe this file will be useful for you too.

I have also tested it on Samsung Galaxy S2 (I9100G, radio: I9100GXXLSP)

Log file:

```
I/AIMSICD (  620): Device type   : GSM
I/AIMSICD (  620): Device imei   : imei
I/AIMSICD (  620): Device version: 01
I/AIMSICD (  620): Device num    : 
I/AIMSICD (  620): Network type  : UMTS
I/AIMSICD (  620): Network CellID: XXXX
I/AIMSICD (  620): Network LAC   : 2111
I/AIMSICD (  620): Network code  : 25002
I/AIMSICD (  620): Network name  : MegaFon RUS
```

RIL OEM Hook Text:
Ciphering Indicator - ServiceMode

```
CIPHERING INFO
Is_connected: 0
in_enciphered: 1
Key status: 2
key_context: 2
RAT: 2
```
