### PR TITLE
OpenCellID - User Specific API Key Support

### DIFF
--- a/app/src/main/java/com/SecUpwN/AIMSICD/activities/MapViewer.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/activities/MapViewer.java
@@ -290,7 +290,7 @@ public class MapViewer extends FragmentActivity implements OnSharedPreferenceCha
                     Location lastKnown = mAimsicdService.mDevice.getLastLocation();
                     if (lastKnown != null) {
                         Helpers.msgShort(this, "Contacting OpenCellID.org for data...");
-                        Cell cell = new Cell();
+                        Cell cell;
                         cell = mAimsicdService.mDevice.mCell;
                         cell.setLon(lastKnown.getLongitude());
                         cell.setLat(lastKnown.getLatitude());

--- a/app/src/main/java/com/SecUpwN/AIMSICD/adapters/AIMSICDDbAdapter.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/adapters/AIMSICDDbAdapter.java
@@ -227,7 +227,7 @@ public class AIMSICDDbAdapter {
      * Returns Cell Information for contribution to the OpenCellID Project
      */
     public Cursor getOPCIDSubmitData() {
-        return mDb.query(CELL_TABLE, new String[]{"Mcc", "Mnc", "Lac", "CellID", "Lng", "Lat",
+        return mDb.query(CELL_TABLE, new String[]{ "Lng", "Lat", "Mcc", "Mnc", "Lac", "CellID",
                         "Signal", "Timestamp", "Accuracy", "Speed", "Direction", "NetworkType"},
                 "OCID_SUBMITTED <> 1", null, null, null, null
         );

--- a/app/src/main/java/com/SecUpwN/AIMSICD/service/AimsicdService.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/service/AimsicdService.java
@@ -137,7 +137,7 @@ public class AimsicdService extends Service implements OnSharedPreferenceChangeL
     public static final String SILENT_SMS = "SILENT_SMS_INTERCEPTED";
     public static final String UPDATE_DISPLAY = "UPDATE_DISPLAY";
     public static int PHONE_TYPE;
-    public static String OCID_API_KEY = "API KEY GOES HERE.......";
+    public static String OCID_API_KEY = "NA";
 
     /*
      * System and helper declarations
@@ -637,6 +637,8 @@ public class AimsicdService extends Service implements OnSharedPreferenceChangeL
                 break;
         }
         REFRESH_RATE = TimeUnit.SECONDS.toMillis(t);
+
+        OCID_API_KEY = prefs.getString(this.getString(R.string.pref_ocid_key), "NA");
 
         if (trackFemtoPref) {
             startTrackingFemto();
@@ -1238,6 +1240,7 @@ public class AimsicdService extends Service implements OnSharedPreferenceChangeL
         final String REFRESH = this.getString(R.string.pref_refresh_key);
         final String DB_VERSION = this.getString(R.string.pref_last_database_backup_version);
         final String OCID_UPLOAD = this.getString(R.string.pref_ocid_upload);
+        final String OCID_KEY = this.getString(R.string.pref_ocid_key);
 
         if (key.equals(KEY_UI_ICONS)) {
             //Update Notification to display selected icon type
@@ -1270,6 +1273,8 @@ public class AimsicdService extends Service implements OnSharedPreferenceChangeL
             LAST_DB_BACKUP_VERSION = sharedPreferences.getInt(DB_VERSION, 1);
         } else if (key.equals(OCID_UPLOAD)) {
             OCID_UPLOAD_PREF = sharedPreferences.getBoolean(OCID_UPLOAD, false);
+        } else if (key.equals(OCID_KEY)) {
+            OCID_API_KEY = sharedPreferences.getString(OCID_KEY, "NA");
         }
     }
 

--- a/app/src/main/java/com/SecUpwN/AIMSICD/utils/Helpers.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/utils/Helpers.java
@@ -130,43 +130,48 @@ public class Helpers {
      */
     public static void getOpenCellData(Context context, Cell cell, char type) {
         if (Helpers.isNetAvailable(context)) {
-            double earthRadius = 6371.01;
+            if (!AimsicdService.OCID_API_KEY.equals("NA")) {
+                double earthRadius = 6371.01;
 
-            if (cell.getLat() != 0.0 && cell.getLon() != 0.0) {
-                //New GeoLocation object to find bounding Coordinates
-                GeoLocation currentLoc = GeoLocation.fromDegrees(cell.getLat(), cell.getLon());
+                if (cell.getLat() != 0.0 && cell.getLon() != 0.0) {
+                    //New GeoLocation object to find bounding Coordinates
+                    GeoLocation currentLoc = GeoLocation.fromDegrees(cell.getLat(), cell.getLon());
 
-                //Calculate the Bounding Coordinates in a 50 mile radius
-                //0 = min 1 = max
-                GeoLocation[] boundingCoords = currentLoc.boundingCoordinates(100, earthRadius);
-                String boundParameter;
+                    //Calculate the Bounding Coordinates in a 50 mile radius
+                    //0 = min 1 = max
+                    GeoLocation[] boundingCoords = currentLoc.boundingCoordinates(100, earthRadius);
+                    String boundParameter;
 
-                //Request OpenCellID data for Bounding Coordinates
-                boundParameter = String.valueOf(boundingCoords[0].getLatitudeInDegrees()) + ","
-                        + String.valueOf(boundingCoords[0].getLongitudeInDegrees()) + ","
-                        + String.valueOf(boundingCoords[1].getLatitudeInDegrees()) + ","
-                        + String.valueOf(boundingCoords[1].getLongitudeInDegrees());
+                    //Request OpenCellID data for Bounding Coordinates
+                    boundParameter = String.valueOf(boundingCoords[0].getLatitudeInDegrees()) + ","
+                            + String.valueOf(boundingCoords[0].getLongitudeInDegrees()) + ","
+                            + String.valueOf(boundingCoords[1].getLatitudeInDegrees()) + ","
+                            + String.valueOf(boundingCoords[1].getLongitudeInDegrees());
 
-                StringBuilder sb = new StringBuilder();
-                sb.append("http://www.opencellid.org/cell/getInArea?key=")
-                        .append(AimsicdService.OCID_API_KEY).append("&BBOX=")
-                        .append(boundParameter);
+                    StringBuilder sb = new StringBuilder();
+                    sb.append("http://www.opencellid.org/cell/getInArea?key=")
+                            .append(AimsicdService.OCID_API_KEY).append("&BBOX=")
+                            .append(boundParameter);
 
-                if (cell.getMCC() != Integer.MAX_VALUE) {
-                    sb.append("&mcc=").append(cell.getMCC());
+                    if (cell.getMCC() != Integer.MAX_VALUE) {
+                        sb.append("&mcc=").append(cell.getMCC());
+                    }
+
+                    if (cell.getMNC() != Integer.MAX_VALUE) {
+                        sb.append("&mnc=").append(cell.getMNC());
+                    }
+
+                    if (cell.getLAC() != Integer.MAX_VALUE) {
+                        sb.append("&lac=").append(cell.getLAC());
+                    }
+
+                    sb.append("&format=csv");
+
+                    new RequestTask(context, type).execute(sb.toString());
                 }
-
-                if (cell.getMNC() != Integer.MAX_VALUE) {
-                    sb.append("&mnc=").append(cell.getMNC());
-                }
-
-                if (cell.getLAC() != Integer.MAX_VALUE) {
-                    sb.append("&lac=").append(cell.getLAC());
-                }
-
-                sb.append("&format=csv");
-
-                new RequestTask(context, type).execute(sb.toString());
+            } else {
+                Helpers.msgShort(context,
+                        "No OpenCellID API Key detected! \nPlease enter your key in settings first");
             }
         } else {
             final AlertDialog.Builder builder = new AlertDialog.Builder(context);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -163,8 +163,11 @@
     <string name="pref_ocid_title">OpenCellID Settings</string>
     <string name="pref_ocid_upload">pref_ocid_upload</string>
     <string name="pref_ui_ocid_upload_title">Contribute Cell Data</string>
-    <string name="pref_ui_ocid_upload_summ">Upload cell information data to the OpenCellID Project (NO personal information is submitted)</string>
+    <string name="pref_ui_ocid_upload_summ">Contribute data to the OpenCellID Project (NO personal information is submitted)</string>
     <string name="pref_cell_table_cleansed">pref_cell_table_cleansed</string>
+    <string name="pref_ocid_key">pref_ocid_key</string>
+    <string name="pref_ocid_key_title">OpenCellID API Key</string>
+    <string name="pref_ocid_key_summ">Enter your OpenCellID API Key here</string>
 
     <!-- MAP PREFERENCES -->
     <string name="pref_map_title">Map Viewer Preferences</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -60,6 +60,10 @@
     <PreferenceCategory
             android:title="@string/pref_ocid_title"
             android:key="pref_key_ocid_settings">
+        <EditTextPreference
+            android:key="@string/pref_ocid_key"
+            android:title="@string/pref_ocid_key_title"
+            android:summary="@string/pref_ocid_key_summ" />
         <CheckBoxPreference
                 android:key="@string/pref_ocid_upload"
                 android:title="@string/pref_ui_ocid_upload_title"


### PR DESCRIPTION
Modifed the OpenCellID methods to only operate if an API Key has been
entered through the application settings, enabling each user to request
and use their own keys.

This will need to be extended once functionality has been confirmed to
provide more instruction to users regarding the registration process,
such as through alert dialogs and details regarding the OCID website etc.

Key is stored on the device and only used when initiating communication
with the OCID servers, as with all previous versions no personal
information is sent to OCID only necessary cell/location information as
required by their API methods.
