### PR TITLE
add abortOnError false - so that gradle build runs without a problem

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,10 @@ android {
     }
     productFlavors {
     }
+
+    lintOptions {
+        abortOnError false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
at the moment the build fails like this:

<pre>
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:lint'.
> Lint found errors in the project; aborting build.
  
  Fix the issues identified by lint, or add the following to your build script to proceed with errors:
  ...
  android {
      lintOptions {
          abortOnError false
      }
  }
  ...
</pre>

this PR fixes this problem
