### PR TITLE
Check current cell against OCID after download

### DIFF
--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/AIMSICD.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/AIMSICD.java
@@ -326,7 +326,7 @@ public class AIMSICD extends BaseActivity implements AsyncResponse {
 
                 cell.setLon(loc.getLongitudeInDegrees());
                 cell.setLat(loc.getLatitudeInDegrees());
-                Helpers.getOpenCellData(this, cell, RequestTask.DBE_DOWNLOAD_REQUEST);
+                Helpers.getOpenCellData(this, cell, RequestTask.DBE_DOWNLOAD_REQUEST, mAimsicdService);
             } else {
                 Helpers.msgShort(this, getString(R.string.waiting_for_location));
 
@@ -355,7 +355,7 @@ public class AIMSICD extends BaseActivity implements AsyncResponse {
         if (Float.floatToRawIntBits(location[0]) == 0
                 && Float.floatToRawIntBits(location[1]) != 0) {
             Helpers.msgLong(this, getString(R.string.contacting_opencellid_for_data));
-            Helpers.getOpenCellData(this, mAimsicdService.getCell(), RequestTask.DBE_DOWNLOAD_REQUEST);
+            Helpers.getOpenCellData(this, mAimsicdService.getCell(), RequestTask.DBE_DOWNLOAD_REQUEST, mAimsicdService);
         } else {
             Helpers.msgLong(this, getString(R.string.unable_to_determine_last_location));
         }

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/activities/MapViewerOsmDroid.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/activities/MapViewerOsmDroid.java
@@ -334,7 +334,7 @@ public final class MapViewerOsmDroid extends BaseActivity implements OnSharedPre
                         cell.setLat(lastKnown.getLatitudeInDegrees());
                         setRefreshActionButtonState(true);
                         TinyDB.getInstance().putBoolean(TinyDbKeys.FINISHED_LOAD_IN_MAP, false);
-                        Helpers.getOpenCellData(this, cell, RequestTask.DBE_DOWNLOAD_REQUEST_FROM_MAP);
+                        Helpers.getOpenCellData(this, cell, RequestTask.DBE_DOWNLOAD_REQUEST_FROM_MAP, mAimsicdService);
                         return true;
                     }
                 }
@@ -347,7 +347,7 @@ public final class MapViewerOsmDroid extends BaseActivity implements OnSharedPre
                     cell.setLon(loc.getLongitude());
                     setRefreshActionButtonState(true);
                     TinyDB.getInstance().putBoolean(TinyDbKeys.FINISHED_LOAD_IN_MAP, false);
-                    Helpers.getOpenCellData(this, cell, RequestTask.DBE_DOWNLOAD_REQUEST_FROM_MAP);
+                    Helpers.getOpenCellData(this, cell, RequestTask.DBE_DOWNLOAD_REQUEST_FROM_MAP, mAimsicdService);
                 } else {
                     Helpers.msgLong(this,
                             getString(R.string.unable_to_determine_last_location));

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/adapters/AIMSICDDbAdapter.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/adapters/AIMSICDDbAdapter.java
@@ -308,6 +308,8 @@ public final class AIMSICDDbAdapter extends SQLiteOpenHelper {
      * This works for now, but we probably should consider populating "DBi_measure"
      * as soon as the API gets a new LAC. Then the detection can be done by SQL,
      * and by just comparing last 2 LAC entries for same CID.
+     *
+     * @return false if LAC is not OK (Cell's LAC differs from Cell's LAC previously stored value in DB)
      */
     public boolean checkLAC(Cell cell) {
         String query = String.format("SELECT * FROM DBi_bts WHERE CID = %d", cell.getCID());  //CID

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/fragments/MapFragment.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/fragments/MapFragment.java
@@ -337,7 +337,7 @@ public final class MapFragment extends InjectionFragment implements OnSharedPref
                         cell.setLat(lastKnown.getLatitudeInDegrees());
                         setRefreshActionButtonState(true);
                         TinyDB.getInstance().putBoolean(TinyDbKeys.FINISHED_LOAD_IN_MAP, false);
-                        Helpers.getOpenCellData((InjectionAppCompatActivity) getActivity(), cell, RequestTask.DBE_DOWNLOAD_REQUEST_FROM_MAP);
+                        Helpers.getOpenCellData((InjectionAppCompatActivity) getActivity(), cell, RequestTask.DBE_DOWNLOAD_REQUEST_FROM_MAP, mAimsicdService);
                         return true;
                     }
                 }
@@ -349,7 +349,7 @@ public final class MapFragment extends InjectionFragment implements OnSharedPref
                     cell.setLon(loc.getLongitude());
                     setRefreshActionButtonState(true);
                     TinyDB.getInstance().putBoolean(TinyDbKeys.FINISHED_LOAD_IN_MAP, false);
-                    Helpers.getOpenCellData((InjectionAppCompatActivity) getActivity(), cell, RequestTask.DBE_DOWNLOAD_REQUEST_FROM_MAP);
+                    Helpers.getOpenCellData((InjectionAppCompatActivity) getActivity(), cell, RequestTask.DBE_DOWNLOAD_REQUEST_FROM_MAP, mAimsicdService);
                 } else {
                     Helpers.msgLong(getActivity(),
                             getString(R.string.unable_to_determine_last_location));

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/service/CellTracker.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/service/CellTracker.java
@@ -550,8 +550,6 @@ public class CellTracker implements SharedPreferences.OnSharedPreferenceChangeLi
 
                         // Detection Logs are made in checkLAC()
                         vibrate(100, Status.MEDIUM);
-                        setNotification();
-
                     } else {
                         mChangedLAC = false;
                     }
@@ -565,7 +563,6 @@ public class CellTracker implements SharedPreferences.OnSharedPreferenceChangeLi
                             vibrate(100, Status.MEDIUM);
 
                             mCellIdNotInOpenDb = true;
-                            setNotification();
                         } else {
                             mCellIdNotInOpenDb = false;
                         }
@@ -594,14 +591,22 @@ public class CellTracker implements SharedPreferences.OnSharedPreferenceChangeLi
                                 "Changing LAC"
                         );*/
                         dbHelper.toEventLog(1, "Changing LAC");
-                        setNotification();
                     } else {
                         mChangedLAC = false;
                     }
-
                 }
         }
+        setNotification();
+    }
 
+    /**
+     * Check device's current cell location's LAC against local database AND verify cell's CID
+     * exists in the OCID database.
+     *
+     * @see #compareLac(CellLocation)
+     */
+    public void compareLacAndOpenDb() {
+        compareLac(tm.getCellLocation());
     }
 
     // Where is this used?

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/Helpers.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/Helpers.java
@@ -189,6 +189,9 @@ import io.freefair.android.util.logging.Logger;
     *
     */
     public static void getOpenCellData(InjectionAppCompatActivity injectionActivity, Cell cell, char type) {
+        getOpenCellData(injectionActivity, cell, type, null);
+    }
+    public static void getOpenCellData(InjectionAppCompatActivity injectionActivity, Cell cell, char type, final AimsicdService service) {
         if (Helpers.isNetAvailable(injectionActivity)) {
             if (!"NA".equals(CellTracker.OCID_API_KEY)) {
                 double earthRadius = 6371.01; // [Km]
@@ -226,7 +229,16 @@ import io.freefair.android.util.logging.Logger;
                     }
 
                     sb.append("&format=csv");
-                    new RequestTask(injectionActivity, type).execute(sb.toString());
+                    new RequestTask(injectionActivity, type, new RequestTask.AsyncTaskCompleteListener() {
+                        @Override
+                        public void onAsyncTaskSucceeded() {
+                            log.verbose("RequestTask's OCID download was successful. Callback rechecking connected cell against database");
+                            service.getCellTracker().compareLacAndOpenDb();
+                        }
+
+                        @Override
+                        public void onAsyncTaskFailed(String result) { }
+                    }).execute(sb.toString());
                 }
             } else {
                 Fragment myFragment = injectionActivity.getSupportFragmentManager().findFragmentByTag(String.valueOf(DrawerMenu.ID.MAIN.ALL_CURRENT_CELL_DETAILS));

--- a/AIMSICD/src/main/res/values/translatable_strings.xml
+++ b/AIMSICD/src/main/res/values/translatable_strings.xml
@@ -268,6 +268,7 @@
     <string name="no_tracked_locations_found">No tracked locations found to show on map.</string>
     <string name="no_data_for_publishing">No data for publishing available.</string>
     <string name="download_error">Download error:</string>
+    <string name="download_timed_out">OpenCellID API request timed out. Try again later?</string>
     <string name="opencellid_data_successfully_received">OpenCellID data successfully received.</string>
     <string name="error_retrieving_opencellid_data">Error retrieving OpenCellID data.\nCheck your network!</string>
     <string name="opencellid_data_successfully_received_markers_updated">OpenCellID data successfully received.\nMap Markers updated.</string>


### PR DESCRIPTION
#### Agreements

- [x] **I have reviewed and accepted the [guidelines for contributing](https://github.com/CellularPrivacy/Android-IMSI-Catcher-Detector/blob/development/.github/CONTRIBUTING.md) to this project.**
- [x] **I have reviewed and closely followed the [Style Guide](https://github.com/CellularPrivacy/Android-IMSI-Catcher-Detector/wiki/Style-Guide) for this Android app.**

---

#### Overview

This should fix #558. I verified the fix in my local area by:

1. Clearing the OCID database so AIMSICD is in a "vanilla" state and going to an area where I'm connected to a cell tower known to OCID.
2. Observing that I'm getting a MEDIUM/yellow since I have no entries in OCID database to compare against
3. Download the BTS data from OCID from the sidebar
4. Observe that the notification has changed from MEDIUM/yellow to OK/green once the successful download toast displays

##### Specifically resolved issues:
- `CellTracker#setNotification()` now always fires when `CellTracker#compareLac(CellLocation)` is called since recovering from a dangerous state should update the notification. Aka from MEDIUM to OK
- `RequestTask` provides a listener interface for completion callbacks so `Helpers#getOpenCellData(...)` fires OCID check on success
- Timeout for OCID download increased from default 10 seconds to 60 seconds, since the OCID API is slow as hell.
- If OCID API times out, we display that to the user as a special error message.

The listener callback interface is a bit crude, but is better than having RequestTask do too much.

---

#### Classification

- [x] Bugfix (non-breaking change which fixes an existing issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (restructuring of existing code without changing its external functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---

#### References

See #558 for feature request.
This PR supersedes #793.

---

#### Screenshots

N/A