### PR TITLE
MapFragment.loadEntries: Return null if not attached

### DIFF
--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/fragments/MapFragment.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/fragments/MapFragment.java
@@ -392,7 +392,7 @@ public final class MapFragment extends InjectionFragment implements OnSharedPref
                  */
                 if (c != null && c.moveToFirst()) {
                     do {
-                        if (isCancelled()) {
+                        if (isCancelled() || !isAdded()) {
                             return null;
                         }
                         // The indexing here is that of DB table
@@ -470,7 +470,7 @@ public final class MapFragment extends InjectionFragment implements OnSharedPref
                 // plot neighbouring cells
                 while (mAimsicdService == null) {
                     try {
-                        if (isCancelled()) {
+                        if (isCancelled() || !isAdded()) {
                             return null;
                         }
                         Thread.sleep(100);
@@ -480,7 +480,7 @@ public final class MapFragment extends InjectionFragment implements OnSharedPref
                 }
                 List<Cell> nc = mAimsicdService.getCellTracker().updateNeighbouringCells();
                 for (Cell cell : nc) {
-                    if (isCancelled()) {
+                    if (isCancelled() || !isAdded()) {
                         return null;
                     }
                     try {


### PR DESCRIPTION
>Thank you for submitting a pull request! Please add below details so that we can merge it faster.

---

#### Agreements
- [x] **I have reviewed and accepted the [guidelines for contributing](https://github.com/CellularPrivacy/Android-IMSI-Catcher-Detector/blob/development/.github/CONTRIBUTING.md) to this project.**
- [x] **I have reviewed and closely followed the [Style Guide](https://github.com/CellularPrivacy/Android-IMSI-Catcher-Detector/wiki/Style-Guide) for this Android app.**

---

#### Overview
AIMSICD crashed before when the MapFragment was opened, then another fragment (eg. DatabaseViewer) was opened afterwards and then the app was closed by the user by double tapping the back button. The MapFragment then threw a `IllegalStateException`.

I added `check isAdded()` to three points in the code to return null if fragment is not attached to prevent a crash when exiting the app.

---

#### Classification
- [x] Bugfix (non-breaking change which fixes an existing issue)

---

#### References
>If your pull request is related to or solves any existing Issues, please link them here.