### PR TITLE
SMS Detection fixup

### DIFF
--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/smsdetection/SmsDetector.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/smsdetection/SmsDetector.java
@@ -164,7 +164,7 @@ public final class SmsDetector extends Thread {
         while (getSmsDetectionState()) {
             try {
                 logcatLine = mLogcatReader.readLine();
-                if (logcatLines.size() >= LOGCAT_BUFFER_MAX_SIZE || logcatLine != null) {
+                if (logcatLines.size() <= LOGCAT_BUFFER_MAX_SIZE || logcatLine != null) {
                     logcatLines.add(logcatLine);
                 } else if (logcatLines.size() == 0) {
                     /**


### PR DESCRIPTION
Fix of lines in LogCat not added to buffer, because of inverted condition. See https://github.com/CellularPrivacy/Android-IMSI-Catcher-Detector/issues/537#issuecomment-203967623