### PR TITLE
Import OCID data from cell_towers.csv

### DIFF
--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/constants/DrawerMenu.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/constants/DrawerMenu.java
@@ -49,6 +49,7 @@ public class DrawerMenu {
          */
         public static class APPLICATION {
             public static final int DOWNLOAD_LOCAL_BTS_DATA = 400;  //Download Local BST Data FIXME     Is this should be "Download Local OCID Data" ?
+            public static final int IMPORT_CELL_TOWERS_DATA = 401;  //Download CellTowers Data
             public static final int UPLOAD_LOCAL_BTS_DATA = 410;    //Upload Local BST Data
             public static final int ADD_GET_OCID_API_KEY = 420;     // Add/Get OCID API key
             public static final int FAQ = 450;                      // TODO Help/FAQ

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/ui/activities/MainActivity.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/ui/activities/MainActivity.java
@@ -298,7 +298,7 @@ public class MainActivity extends BaseActivity implements AsyncResponse {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == ACTIVITY_RESULT_SELECT_CELLTOWERS) {
-            if(resultCode == RESULT_OK){
+            if (resultCode == RESULT_OK) {
                 String celltowersPath = resolveContentUriPath(this, data.getData());
                 log.debug("Chosen file: " + String.valueOf(celltowersPath));
                 importCellTowersData(celltowersPath);
@@ -316,13 +316,12 @@ public class MainActivity extends BaseActivity implements AsyncResponse {
      * @return resolved absolute file path
      */
     @Nullable
-    public static String resolveContentUriPath(final Context context, final Uri uri)
-    {
+    public static String resolveContentUriPath(final Context context, final Uri uri) {
         // DocumentProvider
         if (Build.VERSION.SDK_INT >=  Build.VERSION_CODES.KITKAT &&
                 DocumentsContract.isDocumentUri(context, uri)) {
-            // ExternalStorageProvider
             if ("com.android.externalstorage.documents".equals(uri.getAuthority())) {
+                // ExternalStorageProvider
                 final String docId = DocumentsContract.getDocumentId(uri);
                 final String[] split = docId.split(":");
                 final String type = split[0];
@@ -330,23 +329,18 @@ public class MainActivity extends BaseActivity implements AsyncResponse {
                 if ("primary".equalsIgnoreCase(type)) {
                     return Environment.getExternalStorageDirectory() + "/" + split[1];
                 }
-            }
+            } else if ("com.android.providers.downloads.documents".equals(uri.getAuthority())) {
             // DownloadsProvider
-            else if ("com.android.providers.downloads.documents".equals(uri.getAuthority())) {
-
                 final String id = DocumentsContract.getDocumentId(uri);
                 final Uri contentUri = ContentUris.withAppendedId(
                         Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
 
                 return getUriDataColumn(context, contentUri, null, null);
             }
-        }
-        // MediaStore (and general)
-        else if ("content".equalsIgnoreCase(uri.getScheme())) {
+        } else if ("content".equalsIgnoreCase(uri.getScheme())) {
+            // MediaStore (and general)
             return getUriDataColumn(context, uri, null, null);
-        }
-        // File
-        else if ("file".equalsIgnoreCase(uri.getScheme())) {
+        } else if ("file".equalsIgnoreCase(uri.getScheme())) {
             return uri.getPath();
         }
         return null;
@@ -369,7 +363,7 @@ public class MainActivity extends BaseActivity implements AsyncResponse {
                                           String[] selectionArgs) {
 
         Cursor cursor = null;
-        final String[] projection = { MediaStore.Files.FileColumns.DATA };
+        final String[] projection = {MediaStore.Files.FileColumns.DATA};
 
         try {
             cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
@@ -379,8 +373,9 @@ public class MainActivity extends BaseActivity implements AsyncResponse {
                 return cursor.getString(column_index);
             }
         } finally {
-            if (cursor != null)
+            if (cursor != null) {
                 cursor.close();
+            }
         }
         return null;
     }

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/ui/activities/MainActivity.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/ui/activities/MainActivity.java
@@ -17,7 +17,6 @@ import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.IBinder;
-import android.os.ParcelFileDescriptor;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.widget.DrawerLayout;
@@ -53,6 +52,7 @@ import com.secupwn.aimsicd.utils.LocationServices;
 import com.secupwn.aimsicd.utils.RequestTask;
 
 import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.util.List;
 
 public class MainActivity extends BaseActivity implements AsyncResponse {
@@ -300,8 +300,8 @@ public class MainActivity extends BaseActivity implements AsyncResponse {
                     String type = getContentResolver().getType(data.getData());
                     boolean isGzip = type != null && type.equals("application/octet-stream") &&
                             data.getDataString().endsWith(".gz");
-                    ParcelFileDescriptor parcelFileDescriptor = getContentResolver().openFileDescriptor(data.getData(), "r");
-                    importCellTowersData(parcelFileDescriptor, isGzip);
+                    InputStream importFile = getContentResolver().openInputStream(data.getData());
+                    importCellTowersData(importFile, isGzip);
                 } catch (FileNotFoundException e) {
                     e.printStackTrace();
                     log.error("Cannot open file " + data.getDataString(), e);
@@ -362,7 +362,7 @@ public class MainActivity extends BaseActivity implements AsyncResponse {
         }
     }
 
-    private void importCellTowersData(ParcelFileDescriptor importFile, boolean isGzip) {
+    private void importCellTowersData(InputStream importFile, boolean isGzip) {
 
         Cell cell = new Cell();
         TelephonyManager tm = (TelephonyManager) getSystemService(Context.TELEPHONY_SERVICE);

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/ui/activities/MainActivity.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/ui/activities/MainActivity.java
@@ -267,6 +267,7 @@ public class MainActivity extends BaseActivity implements AsyncResponse {
         } else if (selectedItem.getId() == DrawerMenu.ID.APPLICATION.IMPORT_CELL_TOWERS_DATA) {
             Intent pickFileIntent = new Intent(Intent.ACTION_GET_CONTENT);
             pickFileIntent.setType("*/*");
+            pickFileIntent.addCategory(Intent.CATEGORY_OPENABLE);
             startActivityForResult(pickFileIntent, ACTIVITY_RESULT_SELECT_CELLTOWERS);
         } else if (selectedItem.getId() == DrawerMenu.ID.APPLICATION.QUIT) {
             try {

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/ui/activities/MainActivity.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/ui/activities/MainActivity.java
@@ -51,8 +51,6 @@ import com.secupwn.aimsicd.utils.Icon;
 import com.secupwn.aimsicd.utils.LocationServices;
 import com.secupwn.aimsicd.utils.RequestTask;
 
-import java.io.FileNotFoundException;
-import java.io.InputStream;
 import java.util.List;
 
 public class MainActivity extends BaseActivity implements AsyncResponse {
@@ -296,17 +294,7 @@ public class MainActivity extends BaseActivity implements AsyncResponse {
         if (requestCode == ACTIVITY_RESULT_SELECT_CELLTOWERS) {
             if (resultCode == RESULT_OK) {
                 log.debug("Chosen file: " + data.getDataString());
-                try {
-                    String type = getContentResolver().getType(data.getData());
-                    boolean isGzip = type != null && type.equals("application/octet-stream") &&
-                            data.getDataString().endsWith(".gz");
-                    InputStream importFile = getContentResolver().openInputStream(data.getData());
-                    importCellTowersData(importFile, isGzip);
-                } catch (FileNotFoundException e) {
-                    e.printStackTrace();
-                    log.error("Cannot open file " + data.getDataString(), e);
-                    Helpers.msgShort(this, getString(R.string.error_importing_celltowers_data));
-                }
+                importCellTowersData(data.getData());
             }
         }
     }
@@ -362,7 +350,7 @@ public class MainActivity extends BaseActivity implements AsyncResponse {
         }
     }
 
-    private void importCellTowersData(InputStream importFile, boolean isGzip) {
+    private void importCellTowersData(Uri importFile) {
 
         Cell cell = new Cell();
         TelephonyManager tm = (TelephonyManager) getSystemService(Context.TELEPHONY_SERVICE);
@@ -382,7 +370,7 @@ public class MainActivity extends BaseActivity implements AsyncResponse {
 
             cell.setLon(loc.getLongitudeInDegrees());
             cell.setLat(loc.getLatitudeInDegrees());
-            Helpers.importCellTowersData(this, cell, importFile, isGzip, mAimsicdService);
+            Helpers.importCellTowersData(this, cell, importFile, mAimsicdService);
 
         } else {
             Helpers.msgShort(this, getString(R.string.needs_location));

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/ui/drawer/DrawerMenuActivityConfiguration.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/ui/drawer/DrawerMenuActivityConfiguration.java
@@ -96,6 +96,7 @@ public class DrawerMenuActivityConfiguration {
             //Section Application
             menu.add(DrawerMenuSection.create(DrawerMenu.ID.SECTION_APPLICATION, mContext.getString(R.string.application)));
             menu.add(DrawerMenuItem.create(DrawerMenu.ID.APPLICATION.DOWNLOAD_LOCAL_BTS_DATA, mContext.getString(R.string.get_opencellid), R.drawable.stat_sys_download_anim0, false));
+            menu.add(DrawerMenuItem.create(DrawerMenu.ID.APPLICATION.IMPORT_CELL_TOWERS_DATA, mContext.getString(R.string.import_cell_towers), R.drawable.stat_sys_download_anim0, false));
             menu.add(DrawerMenuItem.create(DrawerMenu.ID.APPLICATION.UPLOAD_LOCAL_BTS_DATA, mContext.getString(R.string.upload_bts), R.drawable.stat_sys_upload_anim0, false));
             menu.add(DrawerMenuItem.create(DrawerMenu.ID.APPLICATION.QUIT, mContext.getString(R.string.quit), R.drawable.ic_action_remove, false));
             mNavItems = menu;

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/ui/drawer/DrawerMenuItem.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/ui/drawer/DrawerMenuItem.java
@@ -90,6 +90,9 @@ public class DrawerMenuItem implements NavDrawerItem {
             case APPLICATION.DOWNLOAD_LOCAL_BTS_DATA:
                 return R.string.help_app_download_local_bts;
 
+            case APPLICATION.IMPORT_CELL_TOWERS_DATA:
+                return R.string.help_app_import_cell_towers;
+
             case APPLICATION.ADD_GET_OCID_API_KEY:
                 return R.string.help_app_add_get_ocid_api_key;
 

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/FixedGZIPInputStream.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/FixedGZIPInputStream.java
@@ -1,0 +1,55 @@
+package com.secupwn.aimsicd.utils;
+
+import android.support.annotation.NonNull;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * GZIPInputStream that works correctly with files more than 2 GiB
+ * <p/>
+ * <p><b>Rationale</b>
+ * <p>Android Java implementation of {@link GZIPInputStream} contains verifyCrc method that
+ * incorrectly checks for gzip size on EOF. It happens when the uncompressed
+ * file is greater than 2 GiB and {@link java.util.zip.Inflater#getTotalOut()} returns
+ * a negative number since the return type is int and {@code Integer.MAX_VALUE} is about 2GiB.
+ * So it throws {@code IOException("Size mismatch")}
+ * <p/>
+ * <p>Oracle already fixed this bug in Java 6 (see https://bugs.openjdk.java.net/browse/JDK-5092263)
+ * but Android implementation is still affected.
+ * <p/>
+ * <p><b>Workaround</b>
+ * <p>If read throws a specific exception in {@code InputStream#read} we are sure that it is an EOF
+ * and we can consume this exception and just return EOF. There could be a problem with a possible
+ * loss of last buffer but it is better than a loss of full stream.
+ */
+public class FixedGZIPInputStream extends FilterInputStream {
+    public FixedGZIPInputStream(GZIPInputStream in) {
+        super(in);
+    }
+
+    @Override
+    public int read(@NonNull byte[] buffer) throws IOException {
+        try {
+            return super.read(buffer);
+        } catch (IOException e) {
+            if (e.getMessage().equals("Size mismatch")) {
+                return -1;
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public int read(@NonNull byte[] buffer, int byteOffset, int byteCount) throws IOException {
+        try {
+            return super.read(buffer, byteOffset, byteCount);
+        } catch (IOException e) {
+            if (e.getMessage().equals("Size mismatch")) {
+                return -1;
+            }
+            throw e;
+        }
+    }
+}

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/Helpers.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/Helpers.java
@@ -24,7 +24,6 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
-import android.os.ParcelFileDescriptor;
 import android.support.v4.app.Fragment;
 import android.text.TextUtils;
 

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/Helpers.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/Helpers.java
@@ -279,6 +279,10 @@ import io.freefair.android.util.logging.Logger;
                     Double.doubleToRawLongBits(cell.getLon()) != 0) {
                 GeoLocation currentLoc = GeoLocation.fromDegrees(cell.getLat(), cell.getLon());
 
+                log.info("OCID location: " + currentLoc.toString() + "  with radius " + radius + " Km.");
+                log.info("OCID MCC is set to: " + cell.getMobileCountryCode());
+                log.info("OCID MNC is set to: " + cell.getMobileNetworkCode());
+
                 new ImportTask(injectionActivity, importFile,
                         cell.getMobileCountryCode(), cell.getMobileNetworkCode(), currentLoc, radius,
                         new ImportTask.AsyncTaskCompleteListener() {

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/Helpers.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/Helpers.java
@@ -24,6 +24,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.net.Uri;
 import android.support.v4.app.Fragment;
 import android.text.TextUtils;
 
@@ -269,7 +270,7 @@ import io.freefair.android.util.logging.Logger;
      *
      */
      public static void importCellTowersData(InjectionAppCompatActivity injectionActivity, Cell cell,
-                                             InputStream importFile, boolean isGzip,
+                                             Uri importFile,
                                              final AimsicdService service) {
         if (Helpers.isNetAvailable(injectionActivity)) {
             int radius = 2; // Use a 2 Km radius with center at GPS location.
@@ -278,7 +279,7 @@ import io.freefair.android.util.logging.Logger;
                     Double.doubleToRawLongBits(cell.getLon()) != 0) {
                 GeoLocation currentLoc = GeoLocation.fromDegrees(cell.getLat(), cell.getLon());
 
-                new ImportTask(injectionActivity, importFile, isGzip,
+                new ImportTask(injectionActivity, importFile,
                         cell.getMobileCountryCode(), cell.getMobileNetworkCode(), currentLoc, radius,
                         new ImportTask.AsyncTaskCompleteListener() {
                     @Override

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/Helpers.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/Helpers.java
@@ -264,12 +264,13 @@ import io.freefair.android.util.logging.Logger;
      * Description:      Imports cell data from the specified file
      *
      * Used:
-     * @param cell Current Cell Information
      * @param celltowersPath path to the cell_towers.csv / cell_towers.csv.gz
+     * @param cell Current Cell Information
+     * @param importFile
      *
      */
      public static void importCellTowersData(InjectionAppCompatActivity injectionActivity, Cell cell,
-                                             ParcelFileDescriptor importFile, boolean isGzip,
+                                             InputStream importFile, boolean isGzip,
                                              final AimsicdService service) {
         if (Helpers.isNetAvailable(injectionActivity)) {
             int radius = 2; // Use a 2 Km radius with center at GPS location.

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/Helpers.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/Helpers.java
@@ -24,6 +24,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.os.ParcelFileDescriptor;
 import android.support.v4.app.Fragment;
 import android.text.TextUtils;
 
@@ -267,7 +268,9 @@ import io.freefair.android.util.logging.Logger;
      * @param celltowersPath path to the cell_towers.csv / cell_towers.csv.gz
      *
      */
-     public static void importCellTowersData(InjectionAppCompatActivity injectionActivity, Cell cell, String celltowersPath, final AimsicdService service) {
+     public static void importCellTowersData(InjectionAppCompatActivity injectionActivity, Cell cell,
+                                             ParcelFileDescriptor importFile, boolean isGzip,
+                                             final AimsicdService service) {
         if (Helpers.isNetAvailable(injectionActivity)) {
             int radius = 2; // Use a 2 Km radius with center at GPS location.
 
@@ -275,7 +278,7 @@ import io.freefair.android.util.logging.Logger;
                     Double.doubleToRawLongBits(cell.getLon()) != 0) {
                 GeoLocation currentLoc = GeoLocation.fromDegrees(cell.getLat(), cell.getLon());
 
-                new ImportTask(injectionActivity, celltowersPath,
+                new ImportTask(injectionActivity, importFile, isGzip,
                         cell.getMobileCountryCode(), cell.getMobileNetworkCode(), currentLoc, radius,
                         new ImportTask.AsyncTaskCompleteListener() {
                     @Override

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/ImportTask.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/ImportTask.java
@@ -1,0 +1,289 @@
+/* Android IMSI-Catcher Detector | (c) AIMSICD Privacy Project
+ * -----------------------------------------------------------
+ * LICENSE:  http://git.io/vki47 | TERMS:  http://git.io/vki4o
+ * -----------------------------------------------------------
+ */
+package com.secupwn.aimsicd.utils;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import com.secupwn.aimsicd.R;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.LineNumberReader;
+import java.io.Reader;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.zip.GZIPInputStream;
+
+import au.com.bytecode.opencsv.CSVReader;
+import io.freefair.android.injection.annotation.Inject;
+import io.freefair.android.injection.app.InjectionAppCompatActivity;
+import io.freefair.android.util.logging.Logger;
+import io.realm.Realm;
+import lombok.Cleanup;
+
+/**
+ * Description:
+ * <p/>
+ * This class is the request handler for Importing data from OpenCellID's cell_towers.csv or
+ * gzipped cell_towers.csv.gz.
+ * Format of the file slightly differs from the OpenCellID's so it is converted on the
+ * fly and filtered by MCC, MNC, location.
+ * <p/>
+ */
+public class ImportTask extends BaseAsyncTask<String, Integer, String> {
+
+    @Inject
+    private Logger log;
+
+    private RealmHelper mDbAdapter;
+    private Context mAppContext;
+    private final String celltowersPath;
+    private final int mobileCountryCode;
+    private final int mobileNetworkCode;
+    private final GeoLocation currentLocation;
+    private final int locationRadius;
+
+    private AsyncTaskCompleteListener mListener;
+
+    /**
+     * @param context           App context
+     * @param celltowersPath    path to file cell_towers.csv or cell_towers.csv.gz
+     * @param mobileCountryCode MCC filter
+     * @param mobileNetworkCode MNC filter
+     * @param currentLocation   GPS location of cell
+     * @param locationRadius    filtering radius
+     * @param listener          Allows the caller of RequestTask to implement success/fail callbacks
+     */
+    public ImportTask(InjectionAppCompatActivity context, String celltowersPath,
+                      int mobileCountryCode, int mobileNetworkCode,
+                      GeoLocation currentLocation, int locationRadius,
+                      AsyncTaskCompleteListener listener) {
+        super(context);
+        this.celltowersPath = celltowersPath;
+        this.mobileCountryCode = mobileCountryCode;
+        this.mobileNetworkCode = mobileNetworkCode;
+        this.currentLocation = currentLocation;
+        this.locationRadius = locationRadius;
+        this.mAppContext = context.getApplicationContext();
+        this.mDbAdapter = new RealmHelper(mAppContext);
+        this.mListener = listener;
+    }
+
+    /**
+     * Imports data from cell_towers.csv
+     * <p/>
+     * <blockquote>
+     * opencellid.csv layout:
+     * lat,lon,mcc,mnc,lac,cellid,averageSignalStrength,range,samples,changeable,radio,rnc,cid,psc,
+     * tac,pci,sid,nid,bid
+     * <p/>
+     * example:
+     * 52.201454,21.065345,260,2,58140,42042781,-59,1234,3,1,UMTS,641,34205,,,,
+     * <p/>
+     * cell_towers.csv layout:
+     * radio,mcc,net,area,cell,unit,lon,lat,range,samples,changeable,created,updated,averageSignal
+     * 0 radio
+     * 1 mcc
+     * 2 net (mnc)
+     * 3 area (lac)
+     * 4 cell (long)
+     * 5 unit
+     * 6 lon
+     * 7 lat
+     * 8 range
+     * 9 samples
+     * 10 changeable
+     * 11 created
+     * 12 updated
+     * 13 averageSignal
+     * <p/>
+     * example:
+     * UMTS,260,2,58140,42042781,,21.03006,52.207811,21,2,1,1379428153,1458591497,-92
+     * </blockquote>
+     */
+    @Override
+    protected String doInBackground(String... commandString) {
+
+        try {
+            @Cleanup Realm realm = Realm.getDefaultInstance();
+
+            log.info("Importing from: " + celltowersPath);
+
+            if (!(new File(celltowersPath).exists())) {
+                log.error("File cannot be found: " + celltowersPath);
+                Helpers.msgLong(mAppContext, "File not found");
+                return "Error";
+            }
+
+            // Prepare filtering values
+            final String mccFilter = String.valueOf(mobileCountryCode);
+            final String mncFilter = String.valueOf(mobileNetworkCode);
+            double earthRadius = 6371.01; // [Km]
+
+            long progress = 0;
+            long failedRecords = 0;
+
+            CSVReader csvReader = new CSVReader(createFileReader());
+            try {
+                String next[];
+
+                csvReader.readNext(); // skip header
+
+                String[] opencellid_csv = new String[14];
+                while ((next = csvReader.readNext()) != null) {
+                    if (next.length < 14) {
+                        log.warn("Not enough values in string: " + Arrays.toString(next));
+                        ++failedRecords;
+                        continue;
+                    }
+                    if (!next[1].equals(mccFilter) || !next[2].equals(mncFilter)) {
+                        continue;
+                    }
+                    if (next[6].isEmpty() || next[7].isEmpty()) {
+                        continue;
+                    }
+                    GeoLocation location = GeoLocation.fromDegrees(Double.parseDouble(next[7]),
+                            Double.parseDouble(next[6]));
+                    if (location.distanceTo(currentLocation, earthRadius) > locationRadius) {
+                        continue;
+                    }
+
+                    try {
+                        // set non-existent range, avgSignal, etc to "0" so they
+                        // will be possibly filtered by checkDBe
+                        opencellid_csv[0] = next[7]; // lat
+                        opencellid_csv[1] = next[6]; // lon
+                        opencellid_csv[2] = next[1]; // mcc
+                        opencellid_csv[3] = next[2]; // mnc
+                        opencellid_csv[4] = next[3]; // lac
+                        opencellid_csv[5] = next[4]; // cellid, long
+                        opencellid_csv[6] = stringOrZero(next[13]); // averageSignalStrength
+                        opencellid_csv[7] = stringOrZero(next[8]); // range
+                        opencellid_csv[8] = stringOrZero(next[9]); // samples
+                        opencellid_csv[9] = stringOrZero(next[10]); // changeable
+                        opencellid_csv[10] = next[0]; // radio
+                        opencellid_csv[11] = null; // rnc, not used
+                        opencellid_csv[12] = null; // cid, not used
+                        opencellid_csv[13] = null; // psc, not present
+
+                        Date dateCreated = dateOrNow(next[11]);
+                        Date dateUpdated = dateOrNow(next[12]);
+
+                        mDbAdapter.addCSVRecord(realm, opencellid_csv, dateCreated, dateUpdated);
+                        ++progress;
+
+                    } catch (NumberFormatException e) {
+                        log.warn("Problem parsing a record: " + Arrays.toString(opencellid_csv), e);
+                        ++failedRecords;
+                    }
+
+                    if ((progress % 100) == 0) {
+                        log.debug("Imported records for now: " + String.valueOf(progress));
+                        // do not know progress because determining line count in gzipped
+                        // multi-gigabyte file is slow
+                        //publishProgress((int) progress, (int) totalRecords);
+                    }
+                    if ((progress % 1000) == 0) {
+                        try {
+                            Thread.sleep(1000); // wait 1 second to allow user to see progress bar.
+                        } catch (InterruptedException ex) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }
+                }
+            } finally {
+                csvReader.close();
+            }
+            log.debug("Imported records: " + String.valueOf(progress));
+            log.debug("Failed records: " + String.valueOf(failedRecords));
+
+            return "Successful";
+
+        } catch (IOException e) {
+            log.warn("Problem reading data from CSV", e);
+            return null;
+        }
+    }
+
+    /**
+     * Creates a new reader for optionally gziped file
+     */
+    @NonNull
+    private Reader createFileReader() throws IOException {
+        InputStream fileStream = new FileInputStream(new File(celltowersPath));
+        if (isPathGzip())
+            fileStream = new FixedGZIPInputStream(new GZIPInputStream(fileStream));
+        return new InputStreamReader(fileStream);
+    }
+
+    private boolean isPathGzip() {
+        return celltowersPath.endsWith(".gz");
+    }
+
+    @NonNull
+    private static Date dateOrNow(String timestamp) {
+        return timestamp == null || timestamp.isEmpty() ? new Date() : new Date(Long.valueOf(timestamp) * 1000);
+    }
+
+    private static String stringOrZero(String s) {
+        return s == null || s.isEmpty() ? "0" : s;
+    }
+
+    /**
+     * This is where we:
+     * <ol>
+     * <li>Check the success for data import</li>
+     * <li>call the updateOpenCellID() to populate the {@link com.secupwn.aimsicd.data.model.Import Import} realm</li>
+     * <li>call the {@link RealmHelper#checkDBe()} to cleanup bad cells from imported data</li>
+     * <li>present a failure/success toast message</li>
+     * <li>set a shared preference to indicate that data has been downloaded:
+     * {@code ocid_downloaded true}</li>
+     * </ol>
+     */
+    @Override
+    protected void onPostExecute(String result) {
+        super.onPostExecute(result);
+        TinyDB tinydb = TinyDB.getInstance();
+
+        @Cleanup Realm realm = Realm.getDefaultInstance();
+
+        // if `result` is null, it will evaluate to false, no need to check for null
+        if ("Successful".equals(result)) {
+
+            Helpers.msgShort(mAppContext, mAppContext.getString(R.string.celltowers_data_successfully_imported));
+
+            realm.executeTransaction(mDbAdapter.checkDBe());
+            tinydb.putBoolean("ocid_downloaded", true);
+        } else {
+            Helpers.msgLong(mAppContext, mAppContext.getString(R.string.error_importing_celltowers_data));
+        }
+
+        if (mListener != null) {
+            if ("Successful".equals(result)) {
+                mListener.onAsyncTaskSucceeded();
+            } else {
+                mListener.onAsyncTaskFailed(result);
+            }
+        }
+    }
+
+    /**
+     * The interface to be implemented by the caller of ImportTask so it can perform contextual
+     * actions once the async task is completed.
+     * <p/>
+     * E.g. rechecking current cell in the newly updated database after OCID imported.
+     */
+    public interface AsyncTaskCompleteListener {
+        void onAsyncTaskSucceeded();
+
+        void onAsyncTaskFailed(String result);
+    }
+}

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/ImportTask.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/ImportTask.java
@@ -12,11 +12,9 @@ import com.secupwn.aimsicd.R;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.LineNumberReader;
 import java.io.Reader;
 import java.util.Arrays;
 import java.util.Date;
@@ -219,8 +217,9 @@ public class ImportTask extends BaseAsyncTask<String, Integer, String> {
     @NonNull
     private Reader createFileReader() throws IOException {
         InputStream fileStream = new FileInputStream(new File(celltowersPath));
-        if (isPathGzip())
+        if (isPathGzip()) {
             fileStream = new FixedGZIPInputStream(new GZIPInputStream(fileStream));
+        }
         return new InputStreamReader(fileStream);
     }
 

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/ImportTask.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/ImportTask.java
@@ -50,6 +50,8 @@ public class ImportTask extends BaseAsyncTask<String, Integer, String> {
 
     private AsyncTaskCompleteListener mListener;
 
+    public static final double EARTH_RADIUS = 6371.01;
+
     /**
      * @param context           App context
      * @param importFile        URI pointing to the file cell_towers.csv or cell_towers.csv.gz
@@ -118,7 +120,6 @@ public class ImportTask extends BaseAsyncTask<String, Integer, String> {
             // Prepare filtering values
             final String mccFilter = String.valueOf(mobileCountryCode);
             final String mncFilter = String.valueOf(mobileNetworkCode);
-            double earthRadius = 6371.01; // [Km]
 
             long progress = 0;
             long failedRecords = 0;
@@ -145,7 +146,7 @@ public class ImportTask extends BaseAsyncTask<String, Integer, String> {
                     }
                     GeoLocation location = GeoLocation.fromDegrees(Double.parseDouble(next[7]),
                             Double.parseDouble(next[6]));
-                    if (location.distanceTo(currentLocation, earthRadius) > locationRadius) {
+                    if (location.distanceTo(currentLocation, EARTH_RADIUS) > locationRadius) {
                         continue;
                     }
 

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/ImportTask.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/utils/ImportTask.java
@@ -6,7 +6,6 @@
 package com.secupwn.aimsicd.utils;
 
 import android.content.Context;
-import android.os.ParcelFileDescriptor;
 import android.support.annotation.NonNull;
 
 import com.secupwn.aimsicd.R;
@@ -42,7 +41,7 @@ public class ImportTask extends BaseAsyncTask<String, Integer, String> {
 
     private RealmHelper mDbAdapter;
     private Context mAppContext;
-    private final ParcelFileDescriptor importFile;
+    private final InputStream importFile;
     private final boolean isGzip;
     private final int mobileCountryCode;
     private final int mobileNetworkCode;
@@ -53,7 +52,7 @@ public class ImportTask extends BaseAsyncTask<String, Integer, String> {
 
     /**
      * @param context           App context
-     * @param importFile        parcel fd pointing to the file cell_towers.csv or cell_towers.csv.gz
+     * @param importFile        input stream pointing to the file cell_towers.csv or cell_towers.csv.gz
      * @param isGzip            whether the importFile is gzipped file
      * @param mobileCountryCode MCC filter
      * @param mobileNetworkCode MNC filter
@@ -62,7 +61,7 @@ public class ImportTask extends BaseAsyncTask<String, Integer, String> {
      * @param listener          Allows the caller of RequestTask to implement success/fail callbacks
      */
     public ImportTask(InjectionAppCompatActivity context,
-                      ParcelFileDescriptor importFile, boolean isGzip,
+                      InputStream importFile, boolean isGzip,
                       int mobileCountryCode, int mobileNetworkCode,
                       GeoLocation currentLocation, int locationRadius,
                       AsyncTaskCompleteListener listener) {
@@ -217,9 +216,9 @@ public class ImportTask extends BaseAsyncTask<String, Integer, String> {
      */
     @NonNull
     private Reader createFileReader() throws IOException {
-        InputStream fileStream = new ParcelFileDescriptor.AutoCloseInputStream(importFile);
+        InputStream fileStream = importFile;
         if (isGzip) {
-            fileStream = new FixedGZIPInputStream(new GZIPInputStream(fileStream));
+            fileStream = new FixedGZIPInputStream(new GZIPInputStream(importFile));
         }
         return new InputStreamReader(fileStream);
     }

--- a/AIMSICD/src/main/res/values/translatable_strings.xml
+++ b/AIMSICD/src/main/res/values/translatable_strings.xml
@@ -38,6 +38,9 @@
     <!-- MAP VIEWER -->
     <string name="get_opencellid">Download BTS Data</string>
 
+    <!-- IMPORT CELLTOWERS.CSV -->
+    <string name="import_cell_towers">Import CellTowers Data</string>
+
     <!-- LAYOUT -->
     <string name="device_info_title">Device Information</string>
     <string name="sim_info_title">SIM Information</string>
@@ -274,6 +277,9 @@
     <string name="error_uploading_bts_data">Error in uploading BTS data to OpenCellID servers!</string>
     <string name="no_opencellid_key_detected">No OpenCellID API Key detected!\nPlease enter your key in settings first.</string>
     <string name="refreshed_cell_id_info">Refreshed CellId info</string>
+    <string name="imporing_celltowers_data">Importing CellTowers data…\nThis may take a while.</string>
+    <string name="celltowers_data_successfully_imported">CellTowers data successfully imported.</string>
+    <string name="error_importing_celltowers_data">Error importing CellTowers data.</string>
     <string name="unable_to_acquire_root_access">Unable to acquire ROOT access on your device.\nAT Command Injection requires ROOT Terminal access.\nPlease check your device is ROOTED and try again.</string>
     <string name="unable_to_detect_busybox">Unable to detect Busybox on your device.\nAT Command Injection requires Busybox components to function correctly.\nPlease check your device has Busybox installed and try again.</string>
     <string name="unknown_error_trying_to_acquire_serial_device">An unknown error has occurred trying to acquire the Serial Device.\nPlease check your logcat for any errors and post them on our Github.</string>
@@ -338,10 +344,12 @@
     <string name="help_app_add_get_ocid_api_key">Get an API key for using the OpenCellID database to upload and download data…</string>
     <string name="help_app_about">Status Icons and Project explained.</string>
     <string name="help_app_download_local_bts">Downloads the OpenCellID Database.</string>
+    <string name="help_app_import_cell_towers">Imports CellTowers Database.</string>
     <string name="help_app_upload_local_bts">Uploads your BTS to the OpenCellID Database.</string>
     <string name="help_app_debugging">Collect and send error logs.</string>
     <string name="help_app_quit">Exit this app.</string>
     <string name="waiting_for_location">Waiting for location…</string>
+    <string name="needs_location">Needs location</string>
     <string name="unique_bts_data">Unique BTS Data</string>
     <string name="bts_measurements">BTS Measurements</string>
     <string name="imported_ocid_data">Imported OpenCellID Data</string>


### PR DESCRIPTION
---
#### Agreements
- [x] **I have reviewed and accepted the [guidelines for contributing](https://github.com/CellularPrivacy/Android-IMSI-Catcher-Detector/blob/development/.github/CONTRIBUTING.md) to this project.**
- [x] **I have reviewed and closely followed the [Style Guide](https://github.com/CellularPrivacy/Android-IMSI-Catcher-Detector/wiki/Style-Guide) for this Android app.**

---
#### Overview

Allow to import locally downloaded OCID data from cell_towers.csv.gz

---
#### Classification
- [ ] Bugfix (non-breaking change which fixes an existing issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (restructuring of existing code without changing its external functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

_Note_
Also slightly refactored RealmHelper without change of functionality.

---
#### References

PR possibly fixes an issue #435 .

Related to discussion in issue #854 about cell_towers.csv .

---
#### Screenshots

![screenshot](https://cloud.githubusercontent.com/assets/481351/17673166/9f3f88b6-6328-11e6-9907-2407514eeed4.png)
1. Added a new menu item "Import CellTowers Data". Choosing this menu launches a standard file chooser intent.
2. A few new toasted notifications added (not shown).
#### Patch description

_Rationale_
OCID allows to download a full daily dump of cell
data in cell_towers.csv.gz or daily incremental data.
Due to bad stability of OCID API it is useful to be able
to locally import cell_towers.csv.

_Proposed changes_
1. Added a drawer menu "Import CellTowers Data" which launches an intent
   to choose a CSV file or gzipped CSV file with CellTowers data.
2. Async loader in ImportTask that reads a full dump and filters
   it locally with MCC, MNC, cell location just like RequestTask does
   by the API call.
3. ImportTask converts data from CellTowers format (documented) to
   the OCID API CSV format and inserts it to the database with help of
   the RealmHelper.
4. RealmHelper is slightly refactored to allow directly insert data
   without an intermediate file.
5. Added a wrapper around GZIPInputStream because Android implementation
   of GZIPInputStream cannot read files larget than 2 GiB.

_Testing_
Tested on Motorola XT1562, Android 6.0.1.
Import from cell_towers.csv.gz fetches approx 1000 records (Moscow) from
29 millions total and took about twenty minutes on debug version.
Unarchived version is much faster.
