### PR TITLE
Fix detecting sim card info from tiktok in android #1023

### DIFF
--- a/AIMSICD/TikTok-SIM-Privacy.md
+++ b/AIMSICD/TikTok-SIM-Privacy.md
@@ -1,0 +1,45 @@
+## TikTok SIM/Telephony Privacy (Non‑root)
+
+This guide explains practical steps to prevent apps (e.g., TikTok) from learning SIM/phone identifiers on Android devices without root.
+
+### 1) Deny phone/SIM permissions
+- Settings → Apps → TikTok → Permissions → Phone → Deny. Also deny SMS/Call log if present.
+- Force stop TikTok, then Clear storage.
+
+### 2) Stronger enforcement with ADB (no root)
+```bash
+# Replace PKG with the exact package of TikTok (e.g., com.zhiliaoapp.musically or com.ss.android.ugc.trill)
+PKG=com.zhiliaoapp.musically
+
+# Revoke telephony-related dangerous permissions
+adb shell pm revoke $PKG android.permission.READ_PHONE_STATE
+adb shell pm revoke $PKG android.permission.READ_PHONE_NUMBERS
+adb shell pm revoke $PKG android.permission.READ_SMS
+adb shell pm revoke $PKG android.permission.READ_CALL_LOG
+
+# Clamp app-ops (Android 10+)
+adb shell cmd appops set $PKG READ_DEVICE_IDENTIFIERS ignore
+adb shell cmd appops set $PKG READ_PHONE_STATE ignore
+adb shell cmd appops set $PKG READ_PHONE_NUMBERS ignore
+adb shell cmd appops set $PKG READ_SMS ignore
+adb shell cmd appops set $PKG READ_CALL_LOG ignore
+
+# Reset the app
+adb shell am force-stop $PKG
+adb shell pm clear $PKG
+```
+
+### 3) Use a secondary Android user without telephony
+- Settings → System → Multiple users → Add user.
+- Do not enable “Phone calls & SMS for this user.”
+- Switch, install TikTok, use Wi‑Fi.
+
+### 4) Temporarily disable the SIM subscription
+- Settings → Network & Internet → SIMs → toggle OFF the problematic SIM.
+- Keep Wi‑Fi ON. Force stop + Clear storage for TikTok before testing.
+
+### Notes
+- Intercepting app traffic is not feasible non‑root due to TLS pinning.
+- Use the new “Privacy Advisor” (App → Menu → Privacy Advisor) to see which installed apps request telephony permissions and copy ready‑made ADB commands.
+
+

--- a/AIMSICD/src/main/AndroidManifest.xml
+++ b/AIMSICD/src/main/AndroidManifest.xml
@@ -104,6 +104,16 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".ui.activities.PrivacyAdvisorActivity"
+            android:label="@string/menu_privacy_advisor"
+            android:parentActivityName=".ui.activities.MainActivity"
+            android:configChanges="keyboardHidden|screenLayout|screenSize|orientation">
+            <intent-filter>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+        </activity>
+
         <service
             android:name=".service.AimsicdService"
             android:enabled="true"

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/ui/activities/MainActivity.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/ui/activities/MainActivity.java
@@ -558,6 +558,10 @@ public class MainActivity extends BaseActivity implements AsyncResponse {
                 Intent i = new Intent(this, DebugLogs.class);
                 startActivity(i);
                 break;
+            case R.id.privacy_advisor:
+                Intent pa = new Intent(this, PrivacyAdvisorActivity.class);
+                startActivity(pa);
+                break;
         }
 
         return mDrawerToggle.onOptionsItemSelected(item) || super.onOptionsItemSelected(item);

--- a/AIMSICD/src/main/java/com/secupwn/aimsicd/ui/activities/PrivacyAdvisorActivity.java
+++ b/AIMSICD/src/main/java/com/secupwn/aimsicd/ui/activities/PrivacyAdvisorActivity.java
@@ -1,0 +1,256 @@
+/* Android IMSI-Catcher Detector | (c) AIMSICD Privacy Project
+ * -----------------------------------------------------------
+ * LICENSE:  http://git.io/vki47 | TERMS:  http://git.io/vki4o
+ * -----------------------------------------------------------
+ */
+package com.secupwn.aimsicd.ui.activities;
+
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.PermissionInfo;
+import android.os.Bundle;
+import android.support.v7.app.AlertDialog;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.ListView;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import com.secupwn.aimsicd.R;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+public class PrivacyAdvisorActivity extends BaseActivity {
+
+	private ListView listView;
+	private ProgressBar progressBar;
+	private TextView emptyView;
+
+	private ArrayAdapter<AppPerms> adapter;
+	private final List<AppPerms> items = new ArrayList<>();
+
+	private static final Set<String> TELEPHONY_PERMS = new HashSet<>(Arrays.asList(
+			android.Manifest.permission.READ_PHONE_STATE,
+			android.Manifest.permission.READ_PHONE_NUMBERS,
+			android.Manifest.permission.READ_SMS,
+			android.Manifest.permission.READ_CALL_LOG
+	));
+
+	@Override
+	protected void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		setContentView(R.layout.activity_privacy_advisor);
+
+		listView = (ListView) findViewById(R.id.privacy_list);
+		progressBar = (ProgressBar) findViewById(R.id.privacy_progress);
+		emptyView = (TextView) findViewById(R.id.privacy_empty);
+
+		adapter = new ArrayAdapter<AppPerms>(this, android.R.layout.simple_list_item_2, android.R.id.text1, items) {
+			@Override
+			public View getView(int position, View convertView, android.view.ViewGroup parent) {
+				View v = super.getView(position, convertView, parent);
+				TextView t1 = (TextView) v.findViewById(android.R.id.text1);
+				TextView t2 = (TextView) v.findViewById(android.R.id.text2);
+				AppPerms ap = getItem(position);
+				if (ap != null) {
+					t1.setText(ap.label + " (" + ap.packageName + ")");
+					t2.setText(getString(R.string.privacy_perms_count, ap.relevantGrantedCount, ap.relevantRequestedCount));
+				}
+				return v;
+			}
+		};
+		listView.setAdapter(adapter);
+		listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+			@Override
+			public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+				AppPerms ap = adapter.getItem(position);
+				if (ap != null) {
+					showDetailsDialog(ap);
+				}
+			}
+		});
+
+		loadData();
+	}
+
+	private void loadData() {
+		progressBar.setVisibility(View.VISIBLE);
+		emptyView.setVisibility(View.GONE);
+		listView.setVisibility(View.GONE);
+
+		new Thread(new Runnable() {
+			@Override
+			public void run() {
+				final List<AppPerms> result = scanInstalled();
+				runOnUiThread(new Runnable() {
+					@Override
+					public void run() {
+						items.clear();
+						items.addAll(result);
+						adapter.notifyDataSetChanged();
+
+						progressBar.setVisibility(View.GONE);
+						if (items.isEmpty()) {
+							emptyView.setVisibility(View.VISIBLE);
+							listView.setVisibility(View.GONE);
+						} else {
+							listView.setVisibility(View.VISIBLE);
+							emptyView.setVisibility(View.GONE);
+						}
+					}
+				});
+			}
+		}).start();
+	}
+
+	private List<AppPerms> scanInstalled() {
+		PackageManager pm = getPackageManager();
+		List<PackageInfo> pkgs = pm.getInstalledPackages(PackageManager.GET_PERMISSIONS);
+		List<AppPerms> result = new ArrayList<>();
+
+		for (PackageInfo pi : pkgs) {
+			if (pi.requestedPermissions == null || pi.requestedPermissions.length == 0) {
+				continue;
+			}
+			List<String> requested = new ArrayList<>();
+			List<String> granted = new ArrayList<>();
+
+			for (int i = 0; i < pi.requestedPermissions.length; i++) {
+				String perm = pi.requestedPermissions[i];
+				if (!TELEPHONY_PERMS.contains(perm)) continue;
+
+				requested.add(perm);
+				boolean isGranted = false;
+				if (pi.requestedPermissionsFlags != null && pi.requestedPermissionsFlags.length > i) {
+					isGranted = (pi.requestedPermissionsFlags[i] & PackageInfo.REQUESTED_PERMISSION_GRANTED) != 0;
+				} else {
+					isGranted = pm.checkPermission(perm, pi.packageName) == PackageManager.PERMISSION_GRANTED;
+				}
+				if (isGranted) {
+					granted.add(perm);
+				}
+			}
+
+			if (!requested.isEmpty()) {
+				CharSequence label;
+				try {
+					label = pm.getApplicationLabel(pm.getApplicationInfo(pi.packageName, 0));
+				} catch (PackageManager.NameNotFoundException e) {
+					label = pi.packageName;
+				}
+				result.add(new AppPerms(pi.packageName, label.toString(), requested, granted));
+			}
+		}
+
+		Collections.sort(result, new Comparator<AppPerms>() {
+			@Override
+			public int compare(AppPerms o1, AppPerms o2) {
+				// Sort by granted count desc, then label
+				int g = Integer.valueOf(o2.relevantGrantedCount).compareTo(o1.relevantGrantedCount);
+				if (g != 0) return g;
+				return o1.label.compareToIgnoreCase(o2.label);
+			}
+		});
+
+		return result;
+	}
+
+	private void showDetailsDialog(final AppPerms ap) {
+		StringBuilder sb = new StringBuilder();
+		sb.append(getString(R.string.privacy_dialog_pkg)).append(" ").append(ap.packageName).append("\n\n");
+		if (!ap.relevantRequested.isEmpty()) {
+			sb.append(getString(R.string.privacy_dialog_requested)).append("\n");
+			for (String rp : ap.relevantRequested) {
+				sb.append("• ").append(humanizePermission(rp));
+				if (ap.relevantGranted.contains(rp)) {
+					sb.append(" ").append(getString(R.string.privacy_dialog_granted));
+				} else {
+					sb.append(" ").append(getString(R.string.privacy_dialog_denied));
+				}
+				sb.append("\n");
+			}
+		}
+
+		final String adb = buildAdbCommands(ap.packageName, ap.relevantRequested);
+
+		new AlertDialog.Builder(this)
+				.setTitle(getString(R.string.privacy_dialog_title, ap.label))
+				.setMessage(sb.toString())
+				.setPositiveButton(R.string.privacy_copy_cmds, new DialogInterface.OnClickListener() {
+					@Override
+					public void onClick(DialogInterface dialog, int which) {
+						copyToClipboard(adb);
+					}
+				})
+				.setNegativeButton(android.R.string.cancel, null)
+				.show();
+	}
+
+	private String humanizePermission(String perm) {
+		if (android.Manifest.permission.READ_PHONE_STATE.equals(perm)) return getString(R.string.perm_read_phone_state);
+		if (android.Manifest.permission.READ_PHONE_NUMBERS.equals(perm)) return getString(R.string.perm_read_phone_numbers);
+		if (android.Manifest.permission.READ_SMS.equals(perm)) return getString(R.string.perm_read_sms);
+		if (android.Manifest.permission.READ_CALL_LOG.equals(perm)) return getString(R.string.perm_read_call_log);
+		return perm;
+	}
+
+	private void copyToClipboard(String text) {
+		ClipboardManager cm = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+		if (cm != null) {
+			cm.setPrimaryClip(ClipData.newPlainText("adb", text));
+		}
+	}
+
+	private String buildAdbCommands(String pkg, List<String> perms) {
+		StringBuilder sb = new StringBuilder();
+		sb.append("# Replace PKG if needed\n");
+		sb.append("PKG=").append(pkg).append("\n\n");
+		for (String p : perms) {
+			sb.append("adb shell pm revoke $PKG ").append(p).append("\n");
+		}
+		// App-ops clamps
+		sb.append("\n# App-ops clamps (Android 10+)\n");
+		sb.append("adb shell cmd appops set $PKG READ_DEVICE_IDENTIFIERS ignore\n");
+		sb.append("adb shell cmd appops set $PKG READ_PHONE_STATE ignore\n");
+		sb.append("adb shell cmd appops set $PKG READ_PHONE_NUMBERS ignore\n");
+		sb.append("adb shell cmd appops set $PKG READ_SMS ignore\n");
+		sb.append("adb shell cmd appops set $PKG READ_CALL_LOG ignore\n");
+		sb.append("\n# Reset app\n");
+		sb.append("adb shell am force-stop $PKG\n");
+		sb.append("adb shell pm clear $PKG\n");
+		return sb.toString();
+	}
+
+	@AllArgsConstructor
+	@ToString
+	private static class AppPerms {
+		@Getter
+		final String packageName;
+		@Getter
+		final String label;
+		@Getter
+		final List<String> relevantRequested;
+		@Getter
+		final List<String> relevantGranted;
+
+		final int relevantRequestedCount() { return relevantRequested == null ? 0 : relevantRequested.size(); }
+		final int relevantGrantedCount() { return relevantGranted == null ? 0 : relevantGranted.size(); }
+	}
+}
+
+

--- a/AIMSICD/src/main/res/layout/activity_privacy_advisor.xml
+++ b/AIMSICD/src/main/res/layout/activity_privacy_advisor.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:orientation="vertical"
+	android:padding="16dp">
+
+	<TextView
+		android:id="@+id/privacy_header"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:text="@string/privacy_header"
+		android:textAppearance="?android:attr/textAppearanceMedium"
+		android:paddingBottom="8dp"/>
+
+	<ProgressBar
+		android:id="@+id/privacy_progress"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:layout_gravity="center_horizontal"
+		android:visibility="gone" />
+
+	<TextView
+		android:id="@+id/privacy_empty"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:text="@string/privacy_empty"
+		android:visibility="gone"
+		android:paddingTop="8dp"/>
+
+	<ListView
+		android:id="@+id/privacy_list"
+		android:layout_width="match_parent"
+		android:layout_height="0dp"
+		android:layout_weight="1"
+		android:divider="@android:color/darker_gray"
+		android:dividerHeight="0.5dp"/>
+
+</LinearLayout>
+
+

--- a/AIMSICD/src/main/res/menu/main_menu.xml
+++ b/AIMSICD/src/main/res/menu/main_menu.xml
@@ -31,4 +31,9 @@
         android:icon="@drawable/ic_action_computer"
         android:title="@string/debugging"
         app:showAsAction="never" />
+    <item
+        android:id="@+id/privacy_advisor"
+        android:icon="@drawable/ic_action_settings"
+        android:title="@string/menu_privacy_advisor"
+        app:showAsAction="never" />
 </menu>

--- a/AIMSICD/src/main/res/values/strings.xml
+++ b/AIMSICD/src/main/res/values/strings.xml
@@ -1,4 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="antenna_map_viewer">Antenna Map Viewer</string>
+    <string name="menu_privacy_advisor">Privacy Advisor</string>
+    <string name="privacy_header">Apps requesting phone/SIM permissions (tap for details)</string>
+    <string name="privacy_empty">No installed apps request telephony-related permissions.</string>
+    <string name="privacy_perms_count">%1$d granted of %2$d requested</string>
+    <string name="privacy_dialog_title">%1$s</string>
+    <string name="privacy_dialog_pkg">Package:</string>
+    <string name="privacy_dialog_requested">Requested telephony permissions:</string>
+    <string name="privacy_dialog_granted">(granted)</string>
+    <string name="privacy_dialog_denied">(denied)</string>
+    <string name="privacy_copy_cmds">Copy ADB commands</string>
+    <string name="perm_read_phone_state">Read phone state</string>
+    <string name="perm_read_phone_numbers">Read phone numbers</string>
+    <string name="perm_read_sms">Read SMS</string>
+    <string name="perm_read_call_log">Read call log</string>
 </resources>


### PR DESCRIPTION
I added a new “Privacy Advisor” feature inside the app that scans installed apps for telephony/SIM-related permissions, shows results, and lets you copy ADB commands to clamp them.
- Launch: open the app → menu → Privacy Advisor.
- What it does: lists apps requesting READ_PHONE_STATE, READ_PHONE_NUMBERS, READ_SMS, READ_CALL_LOG; tap an app to see granted/denied state and copy ADB commands to revoke/ignore and reset the app.
- Docs: added AIMSICD/TikTok-SIM-Privacy.md with step-by-step non-root fixes.

Key Edit:
- Strings added in AIMSICD/src/main/res/values/strings.xml.
- New doc: AIMSICD/TikTok-SIM-Privacy.md.

Status: I created the activity, layout, strings, manifest entry, and menu wiring, plus a troubleshooting doc. 
- Added PrivacyAdvisorActivity with list and details dialog; copy-to-clipboard ADB commands.
- Wired into AndroidManifest.xml and main_menu.xml; handled in MainActivity.
- Added minimal strings and a concise doc (AIMSICD/TikTok-SIM-Privacy.md).

Do this in order until TikTok works
1) Deny TikTok access to phone/SIM, then reset the app
  - Settings > Apps > TikTok > Permissions > Phone → Deny. Also Deny SMS, Contacts, Call logs if present.
  - Force stop TikTok.
  - Storage & cache > Clear storage.
  - Open TikTok on Wi‑Fi and test.
2) Most reliable non‑root: use a secondary Android user with no telephony
  - Settings > System > Multiple users > Add user.
  - When asked, do NOT enable “Phone calls & SMS for this user.”
  - Switch to the new user, connect to Wi‑Fi, install only TikTok, sign in, and test.
3) Stronger clamp (ADB, no root)
  - Enable Developer options and USB debugging.
  - Connect to a PC with ADB, then run:
        adb shell pm list packages | grep -i tiktok
        # Replace PKG with the exact package you see (e.g. com.zhiliaoapp.musically or com.ss.android.ugc.trill)
        PKG=com.zhiliaoapp.musically
        
        # Revoke dangerous telephony permissions
        adb shell pm revoke $PKG android.permission.READ_PHONE_STATE
        adb shell pm revoke $PKG android.permission.READ_PHONE_NUMBERS
        adb shell pm revoke $PKG android.permission.READ_SMS
        adb shell pm revoke $PKG android.permission.READ_CALL_LOG 2>/dev/null || true
        
        # Clamp app-ops that leak telephony identifiers (Android 10+)
        adb shell cmd appops set $PKG READ_DEVICE_IDENTIFIERS ignore
        adb shell cmd appops set $PKG READ_PHONE_STATE ignore
        adb shell cmd appops set $PKG READ_PHONE_NUMBERS ignore
        adb shell cmd appops set $PKG READ_SMS ignore
        
        # Reset the app after changes
        adb shell am force-stop $PKG
        adb shell pm clear $PKG

4) On‑device alternative to ADB (still non‑root)
  - Install Shizuku, start it.
  - Install “App Ops” or “App Manager”; link it to Shizuku.
  - For TikTok, set the same app‑ops above to “Ignore/Deny,” and revoke Phone/SMS permissions.
  - Force stop and clear storage for TikTok, then test.
5) Temporarily disable the SIM subscription while using TikTok
  - Settings > Network & Internet > SIMs > toggle OFF the Syrian SIM (disables subscription, not just data).
  - Keep Wi‑Fi ON.
  - Force stop + Clear storage for TikTok, then test.
  - Dual‑SIM: place the Syrian SIM in slot 2 and disable that slot when using TikTok.
6) Optional: firewall to Wi‑Fi only
  - Install NetGuard or RethinkDNS.
  - For TikTok, block “Mobile data,” allow “Wi‑Fi.”
  - Use this alongside the steps above; it doesn’t hide the SIM but avoids mobile routing.

Notes
- Always force stop + clear storage before re‑testing so TikTok drops any cached region flags.
- Intercepting what TikTok sends isn’t feasible non‑root due to TLS + certificate pinning.
- If all else fails, use the web version in a browser profile or an Android tablet/Chromebook (no cellular stack). On iPhone it already works, as you noted.

Summary
- Deny Phone/SIM access and clear TikTok’s storage; test on Wi‑Fi.
- Best fix: run TikTok in a secondary user without telephony enabled.
- For stronger enforcement, use ADB (or Shizuku + App Ops) to set telephony app‑ops to Ignore.

Contribution by Gittensor, learn more at https://gittensor.io/
